### PR TITLE
Consolidate duplicate utilities across management commands

### DIFF
--- a/malcom/houses/formatting.py
+++ b/malcom/houses/formatting.py
@@ -1,0 +1,32 @@
+"""Shared formatting utilities for playlist management commands."""
+
+from .models import PerformanceSchedule
+
+
+def format_duration(seconds: int | None) -> str:
+    """Format duration in seconds as MM:SS string."""
+    if not seconds:
+        return "-"
+    minutes = seconds // 60
+    secs = seconds % 60
+    return f"{minutes}:{secs:02d}"
+
+
+def format_schedule_time(schedule: PerformanceSchedule) -> str:
+    """Format open/start time for a schedule."""
+    time_str = ""
+    if schedule.open_time:
+        time_str = f" OPEN {schedule.open_time.strftime('%H:%M')}"
+    if schedule.start_time:
+        time_str += f" START {schedule.start_time.strftime('%H:%M')}"
+    return time_str
+
+
+def format_schedule_price(schedule: PerformanceSchedule) -> str:
+    """Format presale/door price for a schedule."""
+    price_str = ""
+    if schedule.presale_price:
+        price_str = f" ADV ¥{schedule.presale_price:,.0f}"
+    if schedule.door_price:
+        price_str += f" DOOR ¥{schedule.door_price:,.0f}"
+    return price_str

--- a/malcom/houses/management/commands/create_monthly_playlist.py
+++ b/malcom/houses/management/commands/create_monthly_playlist.py
@@ -15,11 +15,10 @@ This command:
    - Non-selected performers: increment by 1
 """
 
-import datetime
 import logging
 from pathlib import Path
 
-from commons.functions import get_month_end
+from commons.functions import get_month_end, parse_month
 from django.conf import settings
 from django.core.management import BaseCommand, CommandParser
 from django.db import transaction
@@ -31,20 +30,7 @@ from performers.models import Performer, PerformerSong
 
 logger = logging.getLogger(__name__)
 
-# Constants
-TOP_PERFORMERS_COUNT = 5  # noqa: N806
-YYYY_MM_LENGTH = 7  # noqa: N806
-YYYY_MM_DD_LENGTH = 10  # noqa: N806
-
-
-def date_str(v: str) -> datetime.date:
-    """Parse date string from 'YYYY-MM' or 'YYYY-MM-DD' format."""
-    v = v.strip()
-    if len(v) == YYYY_MM_LENGTH:  # YYYY-MM
-        return datetime.datetime.strptime(v, "%Y-%m").date()  # noqa: DTZ007
-    if len(v) == YYYY_MM_DD_LENGTH:  # YYYY-MM-DD
-        return datetime.datetime.strptime(v, "%Y-%m-%d").date()  # noqa: DTZ007
-    raise ValueError(f"Invalid date format: {v}. Expected 'YYYY-MM' or 'YYYY-MM-DD'")  # noqa: B904
+TOP_PERFORMERS_COUNT = 5
 
 
 class Command(BaseCommand):
@@ -73,15 +59,11 @@ class Command(BaseCommand):
         secrets_file = Path(options["secrets_file"])
         dry_run = options["dry_run"]
 
-        # Parse target month
         try:
-            target_date = date_str(target_month_str)
+            target_date = parse_month(target_month_str)
         except ValueError as e:
             self.stderr.write(self.style.ERROR(str(e)))
             return
-
-        # Set target_date to first day of month
-        target_date = target_date.replace(day=1)
 
         self.stdout.write(f"Creating monthly playlist for {target_date.strftime('%Y-%m')}")
 

--- a/malcom/houses/management/commands/list_monthly_performers.py
+++ b/malcom/houses/management/commands/list_monthly_performers.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from datetime import date, datetime
 
+from commons.functions import get_month_end
 from django.core.management.base import BaseCommand
 from houses.models import PerformanceSchedule
 
@@ -45,15 +46,7 @@ class Command(BaseCommand):
         month = target_date.month
         month_start = date(year, month, 1)
 
-        # Calculate next month for range
-        if month == 12:  # noqa: PLR2004
-            next_month = 1
-            next_year = year + 1
-        else:
-            next_month = month + 1
-            next_year = year
-
-        month_end = date(next_year, next_month, 1)
+        month_end = get_month_end(month_start)
 
         # Get all performances in the target month
         performances = PerformanceSchedule.objects.filter(

--- a/malcom/houses/management/commands/list_monthly_playlist.py
+++ b/malcom/houses/management/commands/list_monthly_playlist.py
@@ -10,37 +10,9 @@ from argparse import ArgumentParser
 from commons.functions import get_month_end, parse_month
 from django.core.management.base import BaseCommand
 from django.db.models import QuerySet
+from houses.formatting import format_duration, format_schedule_price, format_schedule_time
 from houses.models import MonthlyPlaylist, MonthlyPlaylistEntry, PerformanceSchedule
 from performers.models import Performer, PerformerSong
-
-
-def format_duration(seconds: int | None) -> str:
-    """Format duration in seconds as MM:SS string."""
-    if not seconds:
-        return "-"
-    minutes = seconds // 60
-    secs = seconds % 60
-    return f"{minutes}:{secs:02d}"
-
-
-def format_schedule_time(schedule: PerformanceSchedule) -> str:
-    """Format open/start time for a schedule."""
-    time_str = ""
-    if schedule.open_time:
-        time_str = f" OPEN {schedule.open_time.strftime('%H:%M')}"
-    if schedule.start_time:
-        time_str += f" START {schedule.start_time.strftime('%H:%M')}"
-    return time_str
-
-
-def format_schedule_price(schedule: PerformanceSchedule) -> str:
-    """Format presale/door price for a schedule."""
-    price_str = ""
-    if schedule.presale_price:
-        price_str = f" ADV ¥{schedule.presale_price:,.0f}"
-    if schedule.door_price:
-        price_str += f" DOOR ¥{schedule.door_price:,.0f}"
-    return price_str
 
 
 def get_month_boundaries(playlist_date: datetime.date) -> tuple[datetime.date, datetime.date]:

--- a/malcom/houses/management/commands/list_monthlyplaylist_performers.py
+++ b/malcom/houses/management/commands/list_monthlyplaylist_performers.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 
 from commons.functions import get_month_end
 from django.core.management.base import BaseCommand
+from houses.formatting import format_duration
 from houses.models import MonthlyPlaylist, MonthlyPlaylistEntry, PerformanceSchedule
 
 
@@ -125,15 +126,7 @@ class Command(BaseCommand):
                 presale = f"¥{first_schedule.presale_price:,.0f}" if first_schedule.presale_price else "-"
                 door = f"¥{first_schedule.door_price:,.0f}" if first_schedule.door_price else "-"
                 song_title = entry.song.title[:38] if entry.song.title else "-"
-
-                # Format duration as MM:SS
-                if entry.song.youtube_duration_seconds:
-                    minutes = entry.song.youtube_duration_seconds // 60
-                    seconds = entry.song.youtube_duration_seconds % 60
-                    duration = f"{minutes}:{seconds:02d}"
-                else:
-                    duration = "-"
-
+                duration = format_duration(entry.song.youtube_duration_seconds)
                 youtube_url = entry.song.youtube_url or "-"
 
                 self.stdout.write(
@@ -142,17 +135,8 @@ class Command(BaseCommand):
                     f"{presale:<10} {door:<10} {song_title:<40} {duration:<10} {youtube_url:<60}"
                 )
             else:
-                # Show performer even if they have no scheduled performances
                 song_title = entry.song.title[:38] if entry.song.title else "-"
-
-                # Format duration as MM:SS
-                if entry.song.youtube_duration_seconds:
-                    minutes = entry.song.youtube_duration_seconds // 60
-                    seconds = entry.song.youtube_duration_seconds % 60
-                    duration = f"{minutes}:{seconds:02d}"
-                else:
-                    duration = "-"
-
+                duration = format_duration(entry.song.youtube_duration_seconds)
                 youtube_url = entry.song.youtube_url or "-"
                 self.stdout.write(
                     f"{entry.position:<5} {performer.id:<15} {performer.name[:28]:<30} "

--- a/malcom/houses/management/commands/list_weekly_playlist.py
+++ b/malcom/houses/management/commands/list_weekly_playlist.py
@@ -11,37 +11,9 @@ from datetime import timedelta
 from commons.functions import parse_week
 from django.core.management.base import BaseCommand
 from django.db.models import QuerySet
+from houses.formatting import format_duration, format_schedule_price, format_schedule_time
 from houses.models import PerformanceSchedule, WeeklyPlaylist, WeeklyPlaylistEntry
 from performers.models import Performer, PerformerSong
-
-
-def format_duration(seconds: int | None) -> str:
-    """Format duration in seconds as MM:SS string."""
-    if not seconds:
-        return "-"
-    minutes = seconds // 60
-    secs = seconds % 60
-    return f"{minutes}:{secs:02d}"
-
-
-def format_schedule_time(schedule: PerformanceSchedule) -> str:
-    """Format open/start time for a schedule."""
-    time_str = ""
-    if schedule.open_time:
-        time_str = f" OPEN {schedule.open_time.strftime('%H:%M')}"
-    if schedule.start_time:
-        time_str += f" START {schedule.start_time.strftime('%H:%M')}"
-    return time_str
-
-
-def format_schedule_price(schedule: PerformanceSchedule) -> str:
-    """Format presale/door price for a schedule."""
-    price_str = ""
-    if schedule.presale_price:
-        price_str = f" ADV ¥{schedule.presale_price:,.0f}"
-    if schedule.door_price:
-        price_str += f" DOOR ¥{schedule.door_price:,.0f}"
-    return price_str
 
 
 def get_week_boundaries(playlist_date: datetime.date) -> tuple[datetime.date, datetime.date]:

--- a/malcom/houses/youtube_utils.py
+++ b/malcom/houses/youtube_utils.py
@@ -11,15 +11,15 @@ from google.auth.transport.requests import Request
 
 logger = logging.getLogger(__name__)
 
-SCOPES = ["https://www.googleapis.com/auth/youtube.force-ssl"]
+DEFAULT_SCOPES = ["https://www.googleapis.com/auth/youtube.force-ssl"]
 
 
-def get_authorized_youtube_client(client_secrets_file: Path):
+def get_authorized_youtube_client(client_secrets_file: Path, scopes: list[str] | None = None):
     """Get an authorized YouTube API client."""
     api_service_name = "youtube"
     api_version = "v3"
 
-    # Define token cache file path (same directory as secrets file)
+    scopes = scopes or DEFAULT_SCOPES
     token_cache_file = client_secrets_file.parent / "token.pickle"
 
     credentials = None
@@ -46,7 +46,7 @@ def get_authorized_youtube_client(client_secrets_file: Path):
     # Run OAuth flow if no valid credentials
     if not credentials or not credentials.valid:
         logger.info("Running OAuth flow for new credentials")
-        flow = google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file(str(client_secrets_file), SCOPES)
+        flow = google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file(str(client_secrets_file), scopes)
         credentials = flow.run_local_server(port=0)
         logger.info("Successfully obtained new credentials")
 

--- a/malcom/performers/management/commands/backfill_youtube_sociallinks.py
+++ b/malcom/performers/management/commands/backfill_youtube_sociallinks.py
@@ -1,46 +1,14 @@
 import logging
-import pickle
 from pathlib import Path
 
-import google_auth_oauthlib.flow
-import googleapiclient.discovery
 from django.core.management.base import BaseCommand, CommandParser
-from google.auth.transport.requests import Request
+from houses.youtube_utils import get_authorized_youtube_client
 
 from performers.models import Performer, PerformerSocialLink, PerformerSong
 
 logger = logging.getLogger(__name__)
 
-SCOPES = ["https://www.googleapis.com/auth/youtube.readonly"]
-
-
-def get_youtube_client(client_secrets_file: Path):
-    """Get an authorized YouTube API client."""
-    api_service_name = "youtube"
-    api_version = "v3"
-
-    token_cache_file = client_secrets_file.parent / "token.pickle"
-
-    credentials = None
-
-    if token_cache_file.exists():
-        try:
-            credentials = pickle.loads(token_cache_file.read_bytes())  # noqa: S301
-        except Exception:  # noqa: BLE001
-            credentials = None
-
-    if credentials and not credentials.valid and credentials.refresh_token:
-        try:
-            credentials.refresh(Request())
-        except Exception:  # noqa: BLE001
-            credentials = None
-
-    if not credentials or not credentials.valid:
-        flow = google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file(str(client_secrets_file), SCOPES)
-        credentials = flow.run_local_server(port=0)
-        token_cache_file.write_bytes(pickle.dumps(credentials))
-
-    return googleapiclient.discovery.build(api_service_name, api_version, credentials=credentials)
+YOUTUBE_READONLY_SCOPES = ["https://www.googleapis.com/auth/youtube.readonly"]
 
 
 class Command(BaseCommand):
@@ -105,7 +73,7 @@ class Command(BaseCommand):
 
         youtube = None
         if not dry_run:
-            youtube = get_youtube_client(secrets_file)
+            youtube = get_authorized_youtube_client(secrets_file, scopes=YOUTUBE_READONLY_SCOPES)
 
         created_count = 0
         failed_count = 0


### PR DESCRIPTION
## Summary
- Consolidate duplicate YouTube API auth into `youtube_utils.get_authorized_youtube_client()` with configurable `scopes` param, removing duplicate implementation from `backfill_youtube_sociallinks.py`
- Replace local `date_str()` in `create_monthly_playlist` with shared `parse_month()` from `commons.functions`
- Replace inline month-end calculation in `list_monthly_performers` with `get_month_end()`
- Extract `format_duration`, `format_schedule_time`, `format_schedule_price` into `houses/formatting.py`, removing duplicates from `list_weekly_playlist` and `list_monthly_playlist`
- Replace inline duration formatting in `list_monthlyplaylist_performers` with shared `format_duration()`

Net: -97 lines across 8 files.

## Test plan
- [x] `uv run python manage.py test -v2` — all 195 tests passing
- [ ] Run `create_monthly_playlist` and `create_weekly_playlist` to verify YouTube API auth still works
- [ ] Run `backfill_youtube_sociallinks --dry-run` to verify readonly scope path