### PR TITLE
Add GarretCrawler for Garret live house

### DIFF
--- a/malcom/houses/crawlers/__init__.py
+++ b/malcom/houses/crawlers/__init__.py
@@ -8,6 +8,7 @@ from .shinjuku_marble import ShinjukuMarbleCrawler
 from .daisy_bar import DaisyBarCrawler
 from .rockmaykan import RockmaykanCrawler
 from .club_que import ClubQueCrawler
+from .garret import GarretCrawler
 
 __all__ = [
     "LiveHouseWebsiteCrawler",
@@ -21,4 +22,5 @@ __all__ = [
     "DaisyBarCrawler",
     "RockmaykanCrawler",
     "ClubQueCrawler",
+    "GarretCrawler",
 ]

--- a/malcom/houses/crawlers/garret.py
+++ b/malcom/houses/crawlers/garret.py
@@ -1,0 +1,212 @@
+import logging
+import re
+
+from bs4 import BeautifulSoup, Tag
+from django.utils import timezone
+
+from .crawler import CrawlerRegistry, LiveHouseWebsiteCrawler
+
+logger = logging.getLogger(__name__)
+
+SCHEDULE_URL_TEMPLATE = "http://www.cyclone1997.com/garret/g_schedule/garret_{year}schedule_{month}.html"
+
+DECEMBER = 12
+
+# Patterns to skip as non-performer content
+SKIP_PATTERNS = re.compile(
+    r"^INFORMATION COMING SOON|^and more|^TBA$",
+    re.IGNORECASE,
+)
+
+
+@CrawlerRegistry.register("GarretCrawler")
+class GarretCrawler(LiveHouseWebsiteCrawler):
+    """Crawler for Garret website (http://www.cyclone1997.com/garret/)."""
+
+    def fetch_page(self, url: str) -> str:
+        """Override to handle Shift-JIS encoding."""
+        response = self.session.get(url, timeout=self.timeout)
+        response.raise_for_status()
+        response.encoding = "shift_jis"
+        return response.text
+
+    def extract_live_house_info(self, html_content: str) -> dict:
+        """Extract live house info - hardcoded for Garret."""
+        return {
+            "name": "GARRET",
+            "name_kana": "ギャレット",
+            "name_romaji": "GARRET",
+            "address": "",
+            "phone_number": "",
+            "capacity": 0,
+            "opened_date": None,
+        }
+
+    def find_schedule_link(self, html_content: str) -> str | None:
+        """Construct current month schedule URL."""
+        current_date = timezone.localdate()
+        return SCHEDULE_URL_TEMPLATE.format(year=current_date.year, month=current_date.month)
+
+    def extract_performance_schedules(self, html_content: str) -> list[dict]:
+        """Extract schedules from Garret's table-based layout."""
+        soup = self.create_soup(html_content)
+
+        year, month = self._extract_year_month(soup)
+        if not year or not month:
+            logger.warning("Could not extract year/month from Garret schedule page")
+            return []
+
+        schedules = []
+        for table in soup.find_all("table"):
+            schedule = self._parse_event_table(table, year, month)
+            if schedule:
+                schedules.append(schedule)
+
+        logger.info(f"Extracted {len(schedules)} schedules from Garret page ({year}-{month:02d})")
+        return schedules
+
+    def _extract_year_month(self, soup: BeautifulSoup) -> tuple[int | None, int | None]:
+        """Extract year and month from header like '2026.<strong>3 March</strong>'."""
+        body_text = soup.get_text()
+        match = re.search(r"(\d{4})\.\s*(\d{1,2})\s*[A-Za-z]+", body_text)
+        if match:
+            return int(match.group(1)), int(match.group(2))
+        return None, None
+
+    def _parse_event_table(self, table: Tag, year: int, month: int) -> dict | None:
+        """Parse a single event table into a schedule dict."""
+        tds = table.find_all("td")
+        if len(tds) < 2:  # noqa: PLR2004
+            return None
+
+        left_td, right_td = tds[0], tds[1]
+
+        # Extract day from image filename: garret_day/DD.jpg
+        day = self._extract_day_from_images(left_td)
+        if not day:
+            return None
+
+        date_str = f"{year}-{month:02d}-{day:02d}"
+
+        # Extract performers from <strong> tags within the right td
+        performers = self._extract_performers(right_td)
+        if not performers:
+            return None
+
+        # Extract event name (text before the performer strong tags)
+        event_name = self._extract_event_name(right_td)
+
+        # Extract times from right td text (Garret uses "|" separator)
+        right_text = right_td.get_text()
+        times = self._extract_garret_times(right_text)
+
+        return {
+            "date": date_str,
+            "open_time": times.get("open_time"),
+            "start_time": times.get("start_time"),
+            "performers": performers,
+            "performance_name": event_name,
+        }
+
+    def _extract_day_from_images(self, td: Tag) -> int | None:
+        """Extract day number from garret_day image filename."""
+        for img in td.find_all("img"):
+            src = img.get("src", "")
+            match = re.search(r"garret_day/(\d+)\.jpg", src)
+            if match:
+                return int(match.group(1))
+        return None
+
+    def _extract_performers(self, td: Tag) -> list[str]:
+        """Extract performer names from <strong> tags in the right column.
+
+        "X PRESENTS" entries are event names (not performers) and are skipped.
+        """
+        performers = []
+
+        for strong in td.find_all("strong"):
+            # Get text with <br> replaced by newlines
+            for br in strong.find_all("br"):
+                br.replace_with("\n")
+            text = strong.get_text()
+
+            # Skip entire strong block if it's a PRESENTS-only event name
+            stripped = re.sub(r"\n", " ", text).strip()
+            if re.search(r"\bPRESENTS\s*$", stripped, re.IGNORECASE):
+                continue
+
+            # Split by common delimiters: /, newline
+            parts = re.split(r"\s*/\s*|\n", text)
+            for part in parts:
+                name = part.strip()
+                if not name:
+                    continue
+                if SKIP_PATTERNS.search(name):
+                    continue
+                if name not in performers:
+                    performers.append(name)
+
+        return performers
+
+    def _extract_garret_times(self, text: str) -> dict[str, str | None]:
+        """Extract OPEN/START times from Garret format: 'OPEN HH:MM | START HH:MM'."""
+        result: dict[str, str | None] = {"open_time": None, "start_time": None}
+        pattern = r"OPEN\s+(\d{1,2}:\d{2})\s*\|\s*START\s+(\d{1,2}:\d{2})"
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            result["open_time"] = match.group(1)
+            result["start_time"] = match.group(2)
+        return result
+
+    def _extract_event_name(self, td: Tag) -> str | None:
+        """Extract event name from text before the performer strong tags."""
+        # Get the outer span (font-size: 10px) text content
+        span = td.find("span", style=re.compile(r"font-size:\s*10px"))
+        if not span:
+            return None
+
+        # Walk through children to find text before the first font-size: 14px span
+        event_parts = []
+        for child in span.children:
+            # Stop when we hit the performer span/strong area
+            if isinstance(child, Tag):
+                if child.find("span", style=re.compile(r"font-size:\s*14px")):
+                    break
+                if child.find("strong"):
+                    break
+            else:
+                text = str(child).strip()
+                if text:
+                    event_parts.append(text)
+
+        name = " ".join(event_parts).strip()
+        # Clean up common noise
+        name = re.sub(r"^pre\.\s*", "", name, flags=re.IGNORECASE).strip()
+        return name if name else None
+
+    def find_next_month_link(self, html_content: str) -> str | None:
+        """Find next month schedule URL from navigation links."""
+        soup = self.create_soup(html_content)
+
+        # Look for links matching the schedule URL pattern
+        for link in soup.find_all("a", href=True):
+            href = link["href"]
+            match = re.search(r"garret_(\d{4})schedule_(\d{1,2})\.html", href)
+            if not match:
+                continue
+
+            link_year = int(match.group(1))
+            link_month = int(match.group(2))
+
+            # Find the current page's year/month to identify "next"
+            current_year, current_month = self._extract_year_month(soup)
+            if not current_year or not current_month:
+                continue
+
+            # Check if this link is for the next month
+            if link_year == current_year and link_month == current_month + 1:
+                return SCHEDULE_URL_TEMPLATE.format(year=link_year, month=link_month)
+            if link_year == current_year + 1 and current_month == DECEMBER and link_month == 1:
+                return SCHEDULE_URL_TEMPLATE.format(year=link_year, month=link_month)
+
+        return None

--- a/malcom/houses/tests/test_crawlers_garret.py
+++ b/malcom/houses/tests/test_crawlers_garret.py
@@ -1,0 +1,245 @@
+from django.test import TestCase
+
+from houses.crawlers import GarretCrawler
+from houses.definitions import WebsiteProcessingState
+from houses.models import LiveHouseWebsite
+
+# HTML for first date (March 1) - two PRESENTS-only events
+FIRST_DATE_HTML = """\
+<html lang="ja"><head><title>GARRET OPEN!!</title></head><body>
+<font size="+2">
+<a href="garret_2026schedule_2.html"><img src="../../image/logo_left.jpg"></a>
+<b> 2026.<strong>3 March </strong></b>
+<a href="garret_2026schedule_4.html"><img src="../../image/logo_right.jpg"></a>
+</font>
+<hr>
+<table cellpadding="0"><tr>
+<td width="80" height="90" align="center" valign="middle"><em><strong>
+<img src="../../web-content/image/garret_day/01.jpg" height="40" width="40"><br>
+<img src="../../image/garret_week/7sun.jpg" width="40" height="14"><br>
+<img src="../../image/garret_week/daytime_red.jpg" width="70" height="14"><br>
+</strong></em></td>
+<td width="700" valign="middle"><p><span style="font-size: 10px"><br>
+<span style="font-size: 10px; font-weight: normal;">
+<span style="font-size: 14px">
+<strong>わたあめびーすたーず PRESENTS</strong>
+</span></span><br><br>
+OPEN TBA | START TBA<br>
+ADV TBA  | DOOR TBA  (+1D)<br>
+[TICKET INFO] TBA</span></p></td>
+</tr></table>
+<hr>
+<table cellpadding="0"><tr>
+<td width="80" height="90" align="center" valign="middle"><em><strong>
+<img src="../../web-content/image/garret_day/01.jpg" height="40" width="40"><br>
+<img src="../../image/garret_week/7sun.jpg" width="40" height="14"><br>
+</strong></em></td>
+<td width="700" valign="middle"><p><span style="font-size: 10px"><br>
+<span style="font-size: 10px; font-weight: normal;">
+<span style="font-size: 14px">
+<strong>MUSIC FRONTIER PRESENTS</strong>
+</span></span><br><br>
+OPEN TBA | START TBA<br>
+ADV TBA  | DOOR TBA  (+1D)<br>
+[TICKET INFO] TBA</span></p></td>
+</tr></table>
+<hr>
+</body></html>
+"""
+
+# HTML for last date (March 31) - "COMING SOON" plus a real event on day 29
+LAST_DATE_HTML = """\
+<html lang="ja"><head><title>GARRET OPEN!!</title></head><body>
+<font size="+2">
+<a href="garret_2026schedule_2.html"><img src="../../image/logo_left.jpg"></a>
+<b> 2026.<strong>3 March </strong></b>
+<a href="garret_2026schedule_4.html"><img src="../../image/logo_right.jpg"></a>
+</font>
+<hr>
+<table cellpadding="0"><tr>
+<td width="80" height="90" align="center" valign="middle"><em><strong>
+<img src="../../web-content/image/garret_day/29.jpg" height="40" width="40"><br>
+<img src="../../image/garret_week/7sun.jpg" width="40" height="14"><br>
+</strong></em></td>
+<td width="700" valign="middle"><p>
+<span style="font-size: 10px">
+なせぐみ生誕2026<br><br>
+<span style="font-size: 10px; font-weight: normal;">
+<span style="font-size: 14px"><strong>
+ななせぐみ / バンドじゃないもん！MAXX NAKAYOSHI<br>
+グミカナミル&amp;おやすみホログラム
+</strong></span></span><br><br>
+OPEN 18:30 | START 19:00<br>
+ADV &yen;4980  | DOOR TBA  (+1D)<br>
+<a href="https://banmon.jp/contents/1048965">OFFICIAL SITE</a>
+</span></p></td>
+</tr></table>
+<hr>
+<table cellpadding="0"><tr>
+<td width="80" height="90" align="center" valign="middle"><em><strong>
+<img src="../../web-content/image/garret_day/31.jpg" height="40" width="40"><br>
+<img src="../../image/garret_week/2tue.jpg" width="40" height="14"><br>
+</strong></em></td>
+<td width="700" valign="middle"><p><span style="font-size: 10px">pre.<br><br>
+<span style="font-size: 10px; font-weight: normal;">
+<span style="font-size: 14px">
+<strong>INFORMATION COMING SOON...</strong>
+</span><br>and more...</span><br><br>
+OPEN TBA | START TBA<br>
+ADV TBA  | DOOR TBA  (+1D)<br>
+[TICKET INFO] TBA</span></p></td>
+</tr></table>
+<hr>
+</body></html>
+"""
+
+# HTML for mid-month events with multiple performers and times
+MULTI_PERFORMER_HTML = """\
+<html lang="ja"><head><title>GARRET OPEN!!</title></head><body>
+<font size="+2"><b> 2026.<strong>3 March </strong></b></font>
+<hr>
+<table cellpadding="0"><tr>
+<td width="80" height="90" align="center" valign="middle"><em><strong>
+<img src="../../web-content/image/garret_day/07.jpg" height="40" width="40"><br>
+<img src="../../image/garret_week/6sat.jpg" width="40" height="14"><br>
+</strong></em></td>
+<td width="700" valign="middle"><p><span style="font-size: 10px">
+Tweyelight pre.<br><br>
+<span style="font-size: 10px; font-weight: normal;">
+<span style="font-size: 14px"><strong>
+Tweyelight / LADYBABY / Dimrays / BabyFaith<br>
+DREAMY / The Number Zero / Phantom Excaliver<br>
+DIZZYREVERSE / DisconnectCendrillon / はるちょん
+</strong></span></span><br><br>
+OPEN 15:50 | START 16:20<br>
+ADV &yen;4900 | DOOR &yen;5400 (+1D)<br>
+[TICKET INFO] <a href="https://livepocket.jp/e/1nijy">livepocket</a>
+</span></p></td>
+</tr></table>
+<hr>
+<table cellpadding="0"><tr>
+<td width="80" height="90" align="center" valign="middle"><em><strong>
+<img src="../../web-content/image/garret_day/27.jpg" height="40" width="40"><br>
+<img src="../../image/garret_week/5fri.jpg" width="40" height="14"><br>
+</strong></em></td>
+<td width="700" valign="middle"><p><span style="font-size: 10px">
+ストレプトカーパス<br><br>
+<span style="font-size: 10px; font-weight: normal;">
+<span style="font-size: 14px"><strong>
+Days,near LAND / BACKDAV / 283(MouthPeace)<br>
+ONE:BRAiNN / Crows of Scenery
+</strong></span></span><br><br>
+OPEN 17:45 | START 18:15<br>
+ADV &yen;3500| DOOR &yen;4000  (+1D)<br>
+[TICKET INFO] <a href="https://livepocket.jp/e/o_2m4">livepocket</a>
+</span></p></td>
+</tr></table>
+<hr>
+</body></html>
+"""
+
+
+class TestGarretCrawler(TestCase):
+    """Test cases for Garret crawler parsing logic."""
+
+    def setUp(self):
+        self.website = LiveHouseWebsite.objects.create(
+            url="http://www.cyclone1997.com/garret/garret_schedule.html",
+            state=WebsiteProcessingState.NOT_STARTED,
+            crawler_class="GarretCrawler",
+        )
+        self.crawler = GarretCrawler(self.website)
+
+    def test_extract_live_house_info(self):
+        """Garret info is hardcoded."""
+        info = self.crawler.extract_live_house_info("")
+        self.assertEqual(info["name"], "GARRET")
+        self.assertEqual(info["name_kana"], "ギャレット")
+        self.assertEqual(info["name_romaji"], "GARRET")
+
+    def test_first_date_presents_only_skipped(self):
+        """March 1: PRESENTS-only events have no performers, skipped."""
+        schedules = self.crawler.extract_performance_schedules(FIRST_DATE_HTML)
+        self.assertEqual(len(schedules), 0)
+
+    def test_last_date_coming_soon_skipped(self):
+        """March 31 'COMING SOON' skipped, day 29 parses correctly."""
+        schedules = self.crawler.extract_performance_schedules(LAST_DATE_HTML)
+
+        self.assertEqual(len(schedules), 1)
+
+        schedule = schedules[0]
+        self.assertEqual(schedule["date"], "2026-03-29")
+        self.assertEqual(schedule["open_time"], "18:30")
+        self.assertEqual(schedule["start_time"], "19:00")
+        self.assertIn("ななせぐみ", schedule["performers"])
+        self.assertIn(
+            "バンドじゃないもん！MAXX NAKAYOSHI",
+            schedule["performers"],
+        )
+        self.assertIn(
+            "グミカナミル&おやすみホログラム",
+            schedule["performers"],
+        )
+
+    def test_multi_performer_slash_and_br_split(self):
+        """Performers separated by / and <br> all extracted."""
+        schedules = self.crawler.extract_performance_schedules(
+            MULTI_PERFORMER_HTML,
+        )
+
+        self.assertEqual(len(schedules), 2)
+
+        # Day 7: Tweyelight Fest - 10 performers
+        day7 = schedules[0]
+        self.assertEqual(day7["date"], "2026-03-07")
+        self.assertEqual(day7["open_time"], "15:50")
+        self.assertEqual(day7["start_time"], "16:20")
+        expected_performers = [
+            "Tweyelight",
+            "LADYBABY",
+            "Dimrays",
+            "BabyFaith",
+            "DREAMY",
+            "The Number Zero",
+            "Phantom Excaliver",
+            "DIZZYREVERSE",
+            "DisconnectCendrillon",
+            "はるちょん",
+        ]
+        self.assertEqual(day7["performers"], expected_performers)
+
+        # Day 27: 5 performers
+        day27 = schedules[1]
+        self.assertEqual(day27["date"], "2026-03-27")
+        self.assertEqual(day27["open_time"], "17:45")
+        self.assertEqual(day27["start_time"], "18:15")
+        self.assertIn("Days,near LAND", day27["performers"])
+        self.assertIn("BACKDAV", day27["performers"])
+        self.assertIn("283(MouthPeace)", day27["performers"])
+        self.assertIn("ONE:BRAiNN", day27["performers"])
+        self.assertIn("Crows of Scenery", day27["performers"])
+
+    def test_year_month_extraction(self):
+        """Year and month extracted from header text."""
+        soup = self.crawler.create_soup(FIRST_DATE_HTML)
+        year, month = self.crawler._extract_year_month(soup)
+        self.assertEqual(year, 2026)
+        self.assertEqual(month, 3)
+
+    def test_find_next_month_link(self):
+        """Next month link found from navigation arrows."""
+        url = self.crawler.find_next_month_link(FIRST_DATE_HTML)
+        expected = "http://www.cyclone1997.com/garret/g_schedule/garret_2026schedule_4.html"
+        self.assertEqual(url, expected)
+
+    def test_find_next_month_link_no_forward(self):
+        """No next month link when only backward navigation exists."""
+        html = """
+        <html><body>
+        <a href="garret_2026schedule_2.html"><img></a>
+        <b> 2026.<strong>3 March </strong></b>
+        </body></html>
+        """
+        url = self.crawler.find_next_month_link(html)
+        self.assertIsNone(url)


### PR DESCRIPTION
## Summary
- New `GarretCrawler` for `http://www.cyclone1997.com/garret/garret_schedule.html`
- Handles Shift-JIS encoding, image-based date extraction (`garret_day/DD.jpg`), and pipe-separated OPEN/START times
- Skips PRESENTS-only events (no performers) and COMING SOON placeholders
- 7 tests covering first/last date parsing, multi-performer splits, navigation links

## Test plan
- [x] `uv run python manage.py test houses.tests.test_crawlers_garret -v2` — 7 tests pass
- [x] `uv run poe check` — all lint checks pass
- [ ] Register venue via `addwebsite` and run live collection