### PR TITLE
Add playlist lineup display and shared formatting

### DIFF
--- a/malcom/houses/definitions.py
+++ b/malcom/houses/definitions.py
@@ -18,6 +18,21 @@ MAX_SOCIAL_LINKS = 5
 MAX_CONTEXT_CHARS = 200
 MAX_PERFORMERS_IN_CONTEXT = 3
 
+PLAYLIST_TAGS = (
+    "indies",
+    "indierock",
+    "punk",
+    "punkrock",
+    "garagerock",
+    "インディーズ",
+    "インディーズバンド",
+    "underground",
+    "alternative",
+    "alternativerock",
+    "emorock",
+    "jrock",
+)
+
 
 class WebsiteProcessingState(StringEnumWithChoices):
     """Enum representing the state of website processing."""

--- a/malcom/houses/formatting.py
+++ b/malcom/houses/formatting.py
@@ -1,6 +1,16 @@
 """Shared formatting utilities for playlist management commands."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .definitions import PLAYLIST_TAGS
 from .models import PerformanceSchedule
+
+if TYPE_CHECKING:
+    import datetime
+
+    from performers.models import Performer, PerformerSong
 
 
 def format_duration(seconds: int | None) -> str:
@@ -30,3 +40,37 @@ def format_schedule_price(schedule: PerformanceSchedule) -> str:
     if schedule.door_price:
         price_str += f" DOOR ¥{schedule.door_price:,.0f}"
     return price_str
+
+
+def build_lineup_lines(
+    selected_songs: list[tuple[Performer, PerformerSong]],
+    date_start: datetime.date,
+    date_end: datetime.date,
+) -> list[str]:
+    """Build formatted lineup lines from selected performers and their schedules."""
+    lines = []
+    for idx, (performer, _song) in enumerate(selected_songs, start=1):
+        schedules = performer.performance_schedules.filter(
+            performance_date__gte=date_start,
+            performance_date__lt=date_end,
+        ).select_related("live_house")
+        seen = set()
+        for sched in schedules:
+            key = (sched.live_house_id, sched.performance_date)
+            if key in seen:
+                continue
+            seen.add(key)
+            venue_name = sched.live_house.name
+            date_str = sched.performance_date.strftime("%Y-%m-%d")
+            lines.append(f"{idx}. {date_str} {performer.name} @ {venue_name}")
+    return lines
+
+
+def build_playlist_description(period_text: str, lineup_str: str) -> str:
+    """Build YouTube playlist description with lineup and tags."""
+    tags_str = "\n".join(f"#{t}" for t in PLAYLIST_TAGS)
+    return f"""Discover bands performing in TOKYO Live Houses for {period_text}.
+
+{lineup_str}
+
+{tags_str}"""

--- a/malcom/houses/management/commands/create_monthly_playlist.py
+++ b/malcom/houses/management/commands/create_monthly_playlist.py
@@ -24,6 +24,7 @@ from django.core.management import BaseCommand, CommandParser
 from django.db import transaction
 from django.db.models import F
 from django.utils import timezone
+from houses.formatting import build_lineup_lines, build_playlist_description
 from houses.models import MonthlyPlaylist, MonthlyPlaylistEntry
 from houses.youtube_utils import add_video_to_playlist, create_youtube_playlist
 from performers.models import Performer, PerformerSong
@@ -168,6 +169,12 @@ class Command(BaseCommand):
                 ),
             )
 
+        lineup_lines = build_lineup_lines(selected_songs, month_start, month_end)
+
+        self.stdout.write("\nPlaylist lineup:")
+        for line in lineup_lines:
+            self.stdout.write(f"  - {line}")
+
         if dry_run:
             self.stdout.write(self.style.SUCCESS("\n=== DRY RUN - No changes made ==="))
             self.stdout.write(f"Would create playlist with {len(selected_songs)} songs")
@@ -181,28 +188,8 @@ class Command(BaseCommand):
         month_name = target_date.strftime("%B").upper()
         year = target_date.strftime("%Y")
         playlist_title = f"HAKKO-AKKEI {month_name} {year} TOKYO Playlist Introduction"
-
-        # Build description
-        tags = (
-            "indies",
-            "indierock",
-            "punk",
-            "punkrock",
-            "garagerock",
-            "インディーズ",
-            "インディーズバンド",
-            "underground",
-            "alternative",
-            "alternativerock",
-            "emorock",
-            "jrock",
-        )
-        tags_str = "\n".join(f"#{t}" for t in tags)
         month_name = target_date.strftime("%B")
-
-        playlist_description = f"""Discover bands performing in TOKYO Live Houses for {month_name} {year}.
-
-{tags_str}"""
+        playlist_description = build_playlist_description(f"{month_name} {year}", "\n".join(lineup_lines))
 
         try:
             youtube_playlist_id = create_youtube_playlist(playlist_title, playlist_description, secrets_file)

--- a/malcom/houses/management/commands/create_weekly_playlist.py
+++ b/malcom/houses/management/commands/create_weekly_playlist.py
@@ -26,6 +26,7 @@ from django.core.management import BaseCommand, CommandParser
 from django.db import transaction
 from django.db.models import F
 from django.utils import timezone
+from houses.formatting import build_lineup_lines, build_playlist_description
 from houses.models import WeeklyPlaylist, WeeklyPlaylistEntry
 from houses.youtube_utils import add_video_to_playlist, create_youtube_playlist
 from performers.models import Performer, PerformerSocialLink, PerformerSong
@@ -203,6 +204,12 @@ class Command(BaseCommand):
             )
             return
 
+        lineup_lines = build_lineup_lines(selected_songs, week_start, week_end)
+
+        self.stdout.write("\nPlaylist lineup:")
+        for line in lineup_lines:
+            self.stdout.write(f"  - {line}")
+
         if dry_run:
             self.stdout.write(self.style.SUCCESS("\n=== DRY RUN - No changes made ==="))
             self.stdout.write(f"Would create playlist with {len(selected_songs)} songs")
@@ -215,27 +222,7 @@ class Command(BaseCommand):
         # Create YouTube playlist
         week_date_str = target_date.strftime("%Y-%m-%d")
         playlist_title = f"HAKKO-AKKEI WEEK {week_date_str} TOKYO Playlist"
-
-        # Build description
-        tags = (
-            "indies",
-            "indierock",
-            "punk",
-            "punkrock",
-            "garagerock",
-            "インディーズ",
-            "インディーズバンド",
-            "underground",
-            "alternative",
-            "alternativerock",
-            "emorock",
-            "jrock",
-        )
-        tags_str = "\n".join(f"#{t}" for t in tags)
-
-        playlist_description = f"""Discover bands performing in TOKYO Live Houses for week of {week_date_str}.
-
-{tags_str}"""
+        playlist_description = build_playlist_description(f"week of {week_date_str}", "\n".join(lineup_lines))
 
         try:
             youtube_playlist_id = create_youtube_playlist(playlist_title, playlist_description, secrets_file)

--- a/malcom/houses/youtube_utils.py
+++ b/malcom/houses/youtube_utils.py
@@ -83,6 +83,24 @@ def create_youtube_playlist(title: str, description: str, client_secrets_file: P
     return playlist_id
 
 
+def update_youtube_playlist(playlist_id: str, title: str, description: str, client_secrets_file: Path) -> None:
+    """Update an existing YouTube playlist's title and description."""
+    youtube = get_authorized_youtube_client(client_secrets_file)
+
+    request = youtube.playlists().update(
+        part="snippet",
+        body={
+            "id": playlist_id,
+            "snippet": {
+                "title": title,
+                "description": description,
+            },
+        },
+    )
+    request.execute()
+    logger.info(f"Updated YouTube playlist: {title} (ID: {playlist_id})")
+
+
 def add_video_to_playlist(playlist_id: str, video_id: str, client_secrets_file: Path) -> bool:
     """Add a video to a YouTube playlist."""
     youtube = get_authorized_youtube_client(client_secrets_file)


### PR DESCRIPTION
## Summary
- Display performer lineup (`{index}. {date} {name} @ {venue}`) during weekly/monthly playlist creation in both dry-run and live modes
- Extract duplicated tags, description template, and lineup building into shared `build_lineup_lines()` and `build_playlist_description()` in `houses/formatting.py`
- Add `PLAYLIST_TAGS` constant to `houses/definitions.py`
- Add `update_youtube_playlist()` utility to `houses/youtube_utils.py` for updating existing playlist metadata

## Test plan
- [ ] Run `create_weekly_playlist --dry-run` and verify lineup displays
- [ ] Run `create_monthly_playlist --dry-run` and verify lineup displays
- [x] Verify YouTube description includes lineup when creating a real playlist
- [x] `uv run python manage.py test -v2` passes (202 tests)
- [x] `uv run poe check` passes