### PR TITLE
Move SQLite DB to HDD and add privacy policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,7 @@ LIVEHOUSE_ONBOARDING_SPEC.md
 LIVEHOUSE_SEARCH_202602.json
 malcom/staticfiles/
 malcom/staticfiles/*
+
+# Backups and session files
+*.bak
+CHECKPOINT.md

--- a/malcom/malcom/settings.py
+++ b/malcom/malcom/settings.py
@@ -120,7 +120,7 @@ WSGI_APPLICATION = "malcom.wsgi.application"  # noqa: N806
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "NAME": Path(os.getenv("SQLITE_DB_PATH", "/mnt/data/hakoake-backend/db.sqlite3")),
     }
 }
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,37 @@
+# Privacy Policy
+
+**Last updated: 2026-03-27**
+
+## Overview
+
+This application ("malcom") is a private automation tool that manages YouTube playlists for a live music venue channel. It is not a consumer-facing product and is operated solely by its owner.
+
+## Data Accessed
+
+This application uses the YouTube Data API v3 to perform the following actions on behalf of the authenticated channel owner:
+
+- Create and update YouTube playlists
+- Add videos to playlists
+- Read playlist and video metadata
+
+## How Data Is Used
+
+YouTube account data accessed through the API is used exclusively to automate playlist management for the channel owner's own YouTube channel. No data is analysed for any other purpose.
+
+## Data Storage
+
+OAuth credentials (access and refresh tokens) are stored locally on the machine running this application in a file named `token.pickle`. This file is not transmitted to any third party.
+
+No YouTube user data is stored in any database or external system.
+
+## Data Sharing
+
+No data accessed via the YouTube Data API is shared with, sold to, or disclosed to any third party.
+
+## Third-Party Services
+
+This application uses the [YouTube Data API v3](https://developers.google.com/youtube/v3) provided by Google LLC. Use of the YouTube API is subject to [Google's Privacy Policy](https://policies.google.com/privacy) and the [YouTube Terms of Service](https://www.youtube.com/t/terms).
+
+## Contact
+
+For questions about this privacy policy, contact: hakkoake@gmail.com


### PR DESCRIPTION
## Summary

- Move SQLite database to HDD (`/mnt/data/hakoake-backend/db.sqlite3`) and configure path via `SQLITE_DB_PATH` env var in `settings.py`
- Add `privacy-policy.md` for Google OAuth app verification (YouTube Data API publishing requirement)
- Gitignore `*.bak` files and `CHECKPOINT.md`

## Test plan

- [x] Verify `uv run python manage.py showmigrations` connects successfully with the new DB path
- [ ] Verify `SQLITE_DB_PATH` env var override works as expected
- [ ] Confirm `https://github.com/monkut/hakoake-backend/blob/main/privacy-policy.md` renders correctly after merge (for use as Google OAuth consent screen privacy policy URL)