### PR TITLE
feat: add post_weekly_playlist management command

### DIFF
--- a/malcom/commons/instagram_images.py
+++ b/malcom/commons/instagram_images.py
@@ -3,15 +3,18 @@
 Generates two types of images:
 - Playlist cover: numbered artist list with hakoake branding
 - Performer card: performer photo/art + event details overlay
+- QR code slide: QR code + metadata overlay for Instagram carousel
 """
 
 from __future__ import annotations
 
 import io
 import logging
+from datetime import date  # noqa: TC003
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import qrcode
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
 
 if TYPE_CHECKING:
@@ -273,6 +276,126 @@ def generate_performer_card(
         font=_font(22),
         fill=(100, 100, 120),
         anchor="rb",
+    )
+
+    return _to_jpeg(img)
+
+
+def generate_qr_code(url: str, size: int = 300) -> Image.Image:
+    """Generate a QR code image for the given URL."""
+    qr = qrcode.QRCode(
+        version=1,
+        error_correction=qrcode.constants.ERROR_CORRECT_L,
+        box_size=10,
+        border=2,
+    )
+    qr.add_data(url)
+    qr.make(fit=True)
+    qr_img = qr.make_image(fill_color="black", back_color="white")
+    return qr_img.resize((size, size), Image.Resampling.LANCZOS)
+
+
+def _resize_to_square(raw_bytes: bytes, size: int = 1080) -> bytes:
+    """Center-crop raw image bytes to a square JPEG of the given size."""
+    img = Image.open(io.BytesIO(raw_bytes)).convert("RGB")
+    w, h = img.size
+    min_dim = min(w, h)
+    x = (w - min_dim) // 2
+    y = (h - min_dim) // 2
+    cropped = img.crop((x, y, x + min_dim, y + min_dim))
+    resized = cropped.resize((size, size), Image.Resampling.LANCZOS)
+    return _to_jpeg(resized)
+
+
+def generate_qr_slide(
+    url: str,
+    position: int,
+    performer_name: str,
+    venue_name: str,
+    event_name: str,
+    event_date: date,
+) -> bytes:
+    """Generate a 1080x1080 QR code slide with metadata overlay. Returns JPEG bytes.
+
+    Args:
+        url: QR code target URL
+        position: Performer position index in the playlist
+        performer_name: Performer name
+        venue_name: Live house name
+        event_name: PerformanceSchedule.performance_name
+        event_date: PerformanceSchedule.performance_date
+    """
+    img = Image.new("RGB", (IMG_W, IMG_H), BG_COLOR)
+    draw = ImageDraw.Draw(img)
+
+    # --- Top accent bar ---
+    draw.rectangle([(0, 0), (IMG_W, 8)], fill=ACCENT_COLOR)
+
+    # --- Branding ---
+    font_brand = _font(36, bold=True)
+    draw.text((IMG_W // 2, 40), "HAKKO-AKKEI", font=font_brand, fill=ACCENT_COLOR, anchor="mt")
+
+    # --- QR code centered in upper portion ---
+    qr_size = 400
+    qr_img = generate_qr_code(url, qr_size)
+    qr_x = (IMG_W - qr_size) // 2
+    qr_y = 100
+    img.paste(qr_img, (qr_x, qr_y))
+
+    # --- Divider below QR ---
+    divider_y = qr_y + qr_size + 20
+    draw.rectangle([(80, divider_y), (IMG_W - 80, divider_y + 2)], fill=DIVIDER_COLOR)
+
+    # --- Metadata text ---
+    text_y = divider_y + 24
+
+    # Position badge + performer name on same line
+    badge_r = 26
+    badge_cx = 80 + badge_r
+    badge_cy = text_y + badge_r
+    draw.ellipse(
+        [(badge_cx - badge_r, badge_cy - badge_r), (badge_cx + badge_r, badge_cy + badge_r)],
+        fill=ACCENT_COLOR,
+    )
+    draw.text((badge_cx, badge_cy), str(position), font=_font(26, bold=True), fill=TEXT_COLOR, anchor="mm")
+
+    font_name = _font(52, bold=True)
+    draw.text((80 + badge_r * 2 + 16, badge_cy), performer_name, font=font_name, fill=TEXT_COLOR, anchor="lm")
+    text_y += badge_r * 2 + 16
+
+    # Venue
+    font_detail = _font(34)
+    draw.text((IMG_W // 2, text_y), f"📍 {venue_name}", font=font_detail, fill=SECONDARY_COLOR, anchor="mt")
+    text_y += 50
+
+    # Event name (if set)
+    if event_name:
+        font_event = _font(30)
+        lines = _text_wrapped(draw, event_name, font_event, IMG_W - 160)
+        for line in lines[:2]:
+            draw.text((IMG_W // 2, text_y), line, font=font_event, fill=DIM_COLOR, anchor="mt")
+            text_y += 40
+
+    # Event date
+    font_date = _font(34, bold=True)
+    draw.text(
+        (IMG_W // 2, text_y),
+        f"📅 {event_date.strftime('%Y-%m-%d (%a)')}",
+        font=font_date,
+        fill=ACCENT_COLOR,
+        anchor="mt",
+    )
+
+    # --- Bottom accent bar ---
+    draw.rectangle([(0, IMG_H - 8), (IMG_W, IMG_H)], fill=ACCENT_COLOR)
+
+    # --- Scan label above bottom bar ---
+    draw.text(
+        (IMG_W // 2, IMG_H - 40),
+        "Scan QR code for details",
+        font=_font(26),
+        fill=SECONDARY_COLOR,
+        anchor="mm",
     )
 
     return _to_jpeg(img)

--- a/malcom/houses/management/commands/create_weekly_playlist_intro_video.py
+++ b/malcom/houses/management/commands/create_weekly_playlist_intro_video.py
@@ -15,7 +15,7 @@ import logging
 from datetime import timedelta
 from pathlib import Path
 
-import qrcode
+from commons.instagram_images import generate_qr_code
 from django.core.management import BaseCommand, CommandParser
 from houses.models import PerformanceSchedule, WeeklyPlaylist
 from PIL import Image, ImageDraw, ImageFont
@@ -54,22 +54,6 @@ def get_font(size: int, bold: bool = False) -> ImageFont.ImageFont | ImageFont.F
     except Exception:  # noqa: BLE001
         logger.warning(f"Could not load custom font, using default (size {size})")
         return ImageFont.load_default()
-
-
-def generate_qr_code(url: str, size: int = 300) -> Image.Image:
-    """Generate a QR code image for the given URL."""
-    qr = qrcode.QRCode(
-        version=1,
-        error_correction=qrcode.constants.ERROR_CORRECT_L,
-        box_size=10,
-        border=2,
-    )
-    qr.add_data(url)
-    qr.make(fit=True)
-
-    qr_img = qr.make_image(fill_color="black", back_color="white")
-    qr_img = qr_img.resize((size, size), Image.Resampling.LANCZOS)
-    return qr_img
 
 
 def create_artist_slide(

--- a/malcom/houses/management/commands/post_weekly_playlist.py
+++ b/malcom/houses/management/commands/post_weekly_playlist.py
@@ -1,0 +1,237 @@
+"""Post a weekly playlist announcement as a carousel.
+
+Carousel structure:
+  Slide 1      — cover: numbered performer list for the week
+  Slides 2k    — per-performer: event flyer image (or performer card fallback)
+  Slides 2k+1  — per-performer: QR code slide with metadata
+
+Usage:
+    uv run python manage.py post_weekly_playlist
+    uv run python manage.py post_weekly_playlist --playlist-id 42
+    uv run python manage.py post_weekly_playlist --dry-run
+    uv run python manage.py post_weekly_playlist --platform instagram --max-performers 3
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from commons.instagram_images import (
+    INSTAGRAM_HASHTAGS,
+    _resize_to_square,
+    generate_performer_card,
+    generate_playlist_cover,
+    generate_qr_slide,
+)
+from commons.instagram_post import build_caption, post_carousel
+from commons.instagram_utils import get_instagram_token
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandParser
+from houses.formatting import build_lineup_lines, build_playlist_description
+from houses.models import PerformanceSchedule, WeeklyPlaylist, WeeklyPlaylistEntry
+
+logger = logging.getLogger(__name__)
+
+MAX_CAROUSEL_SLIDES = 10
+
+
+def _post_instagram(
+    user_id: str,
+    images: list[tuple[bytes, str]],
+    caption: str,
+    cert_file: object,
+    key_file: object,
+) -> str:
+    token_cache = cert_file.parent / "instagram_token.pickle"
+    token = get_instagram_token(cert_file, key_file, token_cache)
+    return post_carousel(user_id, token.access_token, images, caption)
+
+
+PLATFORM_HANDLERS = {
+    "instagram": _post_instagram,
+}
+
+
+class Command(BaseCommand):
+    help = "Post a weekly playlist announcement as a multi-image carousel"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--playlist-id",
+            type=int,
+            default=None,
+            help="WeeklyPlaylist pk; omit to use the latest by date",
+        )
+        parser.add_argument(
+            "--platform",
+            choices=list(PLATFORM_HANDLERS),
+            default="instagram",
+            help="Posting target (default: instagram)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Log images and caption without posting",
+        )
+        parser.add_argument(
+            "--base-url",
+            default="https://hakoake.com",
+            help="Base URL for QR code links (default: https://hakoake.com)",
+        )
+        parser.add_argument(
+            "--max-performers",
+            type=int,
+            default=4,
+            help="Max performers to include; controls slide count (default: 4)",
+        )
+
+    def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003, PLR0912, PLR0915
+        playlist_id: int | None = options["playlist_id"]
+        platform: str = options["platform"]
+        dry_run: bool = options["dry_run"]
+        base_url: str = options["base_url"].rstrip("/")
+        max_performers: int = options["max_performers"]
+
+        # Validate slide count before doing any work
+        total_slides = 1 + max_performers * 2
+        if total_slides > MAX_CAROUSEL_SLIDES:
+            self.stderr.write(
+                self.style.ERROR(
+                    f"--max-performers {max_performers} would produce {total_slides} slides "
+                    f"(limit is {MAX_CAROUSEL_SLIDES}). "
+                    f"Lower --max-performers to {(MAX_CAROUSEL_SLIDES - 1) // 2} or fewer."
+                )
+            )
+            return
+
+        # --- Resolve playlist ---
+        if playlist_id:
+            try:
+                playlist = WeeklyPlaylist.objects.get(id=playlist_id)
+            except WeeklyPlaylist.DoesNotExist:
+                self.stderr.write(self.style.ERROR(f"WeeklyPlaylist id={playlist_id} not found"))
+                return
+        else:
+            playlist = WeeklyPlaylist.objects.order_by("-date").first()
+            if not playlist:
+                self.stderr.write(self.style.ERROR("No WeeklyPlaylist found"))
+                return
+
+        entries = list(
+            WeeklyPlaylistEntry.objects.filter(playlist=playlist).order_by("position").select_related("song__performer")
+        )
+        if not entries:
+            self.stderr.write(self.style.ERROR("Playlist has no entries"))
+            return
+
+        week_start = playlist.date
+        week_end = week_start + timedelta(days=7)
+        week_label = f"Week of {week_start.strftime('%Y-%m-%d')}"
+
+        self.stdout.write(f"Playlist: {playlist.id} — {week_label}")
+        self.stdout.write(f"Entries: {len(entries)}, max performers: {max_performers}")
+
+        # --- Build caption ---
+        performer_song_pairs = [(e.song.performer, e.song) for e in entries]
+        lineup_lines = build_lineup_lines(performer_song_pairs, week_start, week_end)
+        lineup_str = "\n".join(lineup_lines)
+        period_text = f"week of {week_start.strftime('%Y-%m-%d')}"
+        description = build_playlist_description(period_text, lineup_str)
+        playlist_url = (
+            playlist.youtube_playlist_url or f"https://www.youtube.com/playlist?list={playlist.youtube_playlist_id}"
+        )
+        caption = build_caption(description, playlist_url, INSTAGRAM_HASHTAGS)
+
+        if dry_run:
+            self.stdout.write("\n--- CAPTION ---")
+            self.stdout.write(caption)
+            self.stdout.write(f"\nCaption length: {len(caption)} chars")
+
+        # --- Cover slide ---
+        cover_entries = [(e.position, e.song.performer.name) for e in entries]
+        title = f"HAKKO-AKKEI WEEK {week_start.strftime('%Y-%m-%d')} TOKYO Playlist"
+        cover_bytes = generate_playlist_cover(title, week_label, cover_entries)
+        self.stdout.write(f"Generated cover image ({len(cover_bytes):,} bytes)")
+        images: list[tuple[bytes, str]] = [(cover_bytes, "cover.jpg")]
+
+        # --- Per-performer slides ---
+        for entry in entries[:max_performers]:
+            performer = entry.song.performer
+            pos = entry.position
+
+            schedule = (
+                PerformanceSchedule.objects.filter(
+                    performers=performer,
+                    performance_date__gte=week_start,
+                    performance_date__lt=week_end,
+                )
+                .select_related("live_house")
+                .order_by("performance_date")
+                .first()
+            )
+
+            # Flyer slide
+            if schedule and schedule.event_image and schedule.event_image.name:
+                try:
+                    with schedule.event_image.open("rb") as f:
+                        raw = f.read()
+                    flyer_bytes = _resize_to_square(raw, 1080)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(f"Could not load event_image for {performer.name}: {exc}; using performer card")
+                    all_schedules = list(
+                        PerformanceSchedule.objects.filter(
+                            performers=performer,
+                            performance_date__gte=week_start,
+                            performance_date__lt=week_end,
+                        ).select_related("live_house")
+                    )
+                    flyer_bytes = generate_performer_card(performer, pos, all_schedules)
+            else:
+                all_schedules = list(
+                    PerformanceSchedule.objects.filter(
+                        performers=performer,
+                        performance_date__gte=week_start,
+                        performance_date__lt=week_end,
+                    ).select_related("live_house")
+                )
+                flyer_bytes = generate_performer_card(performer, pos, all_schedules)
+
+            flyer_filename = f"flyer_{pos:02d}_{performer.name[:20].replace(' ', '_')}.jpg"
+            images.append((flyer_bytes, flyer_filename))
+            self.stdout.write(f"Generated flyer for {performer.name} ({len(flyer_bytes):,} bytes)")
+
+            # QR code slide
+            qr_url = f"{base_url}/performer/{performer.id}/"
+            venue_name = schedule.live_house.name if schedule else ""
+            event_name = schedule.performance_name if schedule else ""
+            event_date = schedule.performance_date if schedule else week_start
+
+            qr_bytes = generate_qr_slide(
+                url=qr_url,
+                position=pos,
+                performer_name=performer.name,
+                venue_name=venue_name,
+                event_name=event_name,
+                event_date=event_date,
+            )
+            qr_filename = f"qr_{pos:02d}_{performer.name[:20].replace(' ', '_')}.jpg"
+            images.append((qr_bytes, qr_filename))
+            self.stdout.write(f"Generated QR slide for {performer.name} ({len(qr_bytes):,} bytes)")
+
+        self.stdout.write(f"Total slides: {len(images)}")
+
+        if dry_run:
+            self.stdout.write(self.style.SUCCESS(f"\nDry run complete — {len(images)} images generated, not posted"))
+            return
+
+        # --- Post ---
+        if not settings.INSTAGRAM_USER_ID:
+            self.stderr.write(self.style.ERROR("INSTAGRAM_USER_ID not set in .env"))
+            return
+
+        cert_file = settings.OAUTH_LOCALHOST_CERT
+        key_file = settings.OAUTH_LOCALHOST_KEY
+        handler = PLATFORM_HANDLERS[platform]
+        post_id = handler(settings.INSTAGRAM_USER_ID, images, caption, cert_file, key_file)
+        self.stdout.write(self.style.SUCCESS(f"Posted to {platform}: post_id={post_id}"))

--- a/malcom/houses/tests/test_instagram_images.py
+++ b/malcom/houses/tests/test_instagram_images.py
@@ -1,0 +1,77 @@
+"""Unit tests for commons/instagram_images.py — generate_qr_slide and helpers."""
+
+from __future__ import annotations
+
+import io
+from datetime import date
+
+from commons.instagram_images import _resize_to_square, generate_qr_slide
+from django.test import TestCase
+from PIL import Image
+
+
+class TestResizeToSquare(TestCase):
+    def _make_jpeg(self, w: int, h: int) -> bytes:
+        buf = io.BytesIO()
+        Image.new("RGB", (w, h), color=(100, 150, 200)).save(buf, format="JPEG")
+        return buf.getvalue()
+
+    def test_square_input_unchanged_size(self) -> None:
+        raw = self._make_jpeg(800, 800)
+        result = _resize_to_square(raw, 1080)
+        img = Image.open(io.BytesIO(result))
+        self.assertEqual(img.size, (1080, 1080))
+
+    def test_wide_image_becomes_square(self) -> None:
+        raw = self._make_jpeg(1920, 1080)
+        result = _resize_to_square(raw, 1080)
+        img = Image.open(io.BytesIO(result))
+        self.assertEqual(img.size, (1080, 1080))
+
+    def test_tall_image_becomes_square(self) -> None:
+        raw = self._make_jpeg(600, 1200)
+        result = _resize_to_square(raw, 1080)
+        img = Image.open(io.BytesIO(result))
+        self.assertEqual(img.size, (1080, 1080))
+
+    def test_returns_jpeg_bytes(self) -> None:
+        raw = self._make_jpeg(400, 400)
+        result = _resize_to_square(raw, 200)
+        self.assertEqual(result[:2], b"\xff\xd8")
+
+
+class TestGenerateQrSlide(TestCase):
+    def _slide(self, **kwargs) -> bytes:
+        defaults = {
+            "url": "https://hakoake.com/performer/1/",
+            "position": 1,
+            "performer_name": "TestBand",
+            "venue_name": "Club Malcom",
+            "event_name": "Spring Live 2026",
+            "event_date": date(2026, 4, 5),
+        }
+        defaults.update(kwargs)
+        return generate_qr_slide(**defaults)
+
+    def test_returns_jpeg_bytes(self) -> None:
+        result = self._slide()
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(result[:2], b"\xff\xd8")
+
+    def test_output_is_1080x1080(self) -> None:
+        result = self._slide()
+        img = Image.open(io.BytesIO(result))
+        self.assertEqual(img.size, (1080, 1080))
+
+    def test_non_empty_output(self) -> None:
+        result = self._slide()
+        self.assertGreater(len(result), 10_000)
+
+    def test_empty_event_name_does_not_crash(self) -> None:
+        result = self._slide(event_name="")
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(result[:2], b"\xff\xd8")
+
+    def test_long_performer_name(self) -> None:
+        result = self._slide(performer_name="A" * 50)
+        self.assertIsInstance(result, bytes)

--- a/malcom/houses/tests/test_post_weekly_playlist.py
+++ b/malcom/houses/tests/test_post_weekly_playlist.py
@@ -1,0 +1,99 @@
+"""Tests for the post_weekly_playlist management command."""
+
+from __future__ import annotations
+
+from datetime import date
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+from performers.models import Performer, PerformerSong
+
+from houses.models import WeeklyPlaylist, WeeklyPlaylistEntry
+
+
+def _make_performer(name: str = "TestBand") -> Performer:
+    performer = Performer(name=name, name_kana="テスト", name_romaji=name)
+    performer._skip_image_fetch = True  # noqa: SLF001
+    performer.save()
+    return performer
+
+
+def _make_song(performer: Performer, title: str = "Test Song", video_id: str = "abc123") -> PerformerSong:
+    return PerformerSong.objects.create(
+        performer=performer,
+        title=title,
+        youtube_video_id=video_id,
+        youtube_url=f"https://www.youtube.com/watch?v={video_id}",
+        youtube_view_count=1000,
+        youtube_duration_seconds=200,
+    )
+
+
+class TestPostWeeklyPlaylistCommand(TestCase):
+    def setUp(self) -> None:
+        self.performer = _make_performer()
+        self.song = _make_song(self.performer)
+        self.playlist = WeeklyPlaylist.objects.create(
+            date=date(2026, 3, 30),
+            youtube_playlist_id="PLtest123",
+            youtube_playlist_url="https://www.youtube.com/playlist?list=PLtest123",
+        )
+        WeeklyPlaylistEntry.objects.create(playlist=self.playlist, song=self.song, position=1)
+
+    def test_dry_run_does_not_post(self) -> None:
+        out = StringIO()
+        with patch("commons.instagram_post.post_carousel") as mock_post:
+            call_command("post_weekly_playlist", "--dry-run", stdout=out)
+        mock_post.assert_not_called()
+        self.assertIn("Dry run complete", out.getvalue())
+
+    def test_dry_run_with_explicit_playlist_id(self) -> None:
+        out = StringIO()
+        with patch("commons.instagram_post.post_carousel") as mock_post:
+            call_command("post_weekly_playlist", f"--playlist-id={self.playlist.id}", "--dry-run", stdout=out)
+        mock_post.assert_not_called()
+        output = out.getvalue()
+        self.assertIn("Dry run complete", output)
+        self.assertIn(str(self.playlist.id), output)
+
+    def test_dry_run_output_contains_caption(self) -> None:
+        out = StringIO()
+        call_command("post_weekly_playlist", "--dry-run", stdout=out)
+        output = out.getvalue()
+        self.assertIn("CAPTION", output)
+        self.assertIn("PLtest123", output)
+
+    def test_dry_run_generates_cover_and_slides(self) -> None:
+        out = StringIO()
+        call_command("post_weekly_playlist", "--dry-run", stdout=out)
+        output = out.getvalue()
+        self.assertIn("cover image", output)
+        self.assertIn("TestBand", output)
+        self.assertIn("Total slides", output)
+
+    def test_invalid_playlist_id_exits_gracefully(self) -> None:
+        err = StringIO()
+        call_command("post_weekly_playlist", "--playlist-id=99999", "--dry-run", stderr=err)
+        self.assertIn("not found", err.getvalue())
+
+    def test_max_performers_exceeded_exits_gracefully(self) -> None:
+        err = StringIO()
+        # max_performers=5 -> 11 slides, over the limit of 10
+        call_command("post_weekly_playlist", "--max-performers=5", "--dry-run", stderr=err)
+        self.assertIn("slides", err.getvalue())
+
+    def test_uses_latest_playlist_when_no_id_given(self) -> None:
+        newer_playlist = WeeklyPlaylist.objects.create(
+            date=date(2026, 4, 6),
+            youtube_playlist_id="PLnewer",
+            youtube_playlist_url="https://www.youtube.com/playlist?list=PLnewer",
+        )
+        song2 = _make_song(self.performer, title="Newer Song", video_id="newer123")
+        WeeklyPlaylistEntry.objects.create(playlist=newer_playlist, song=song2, position=1)
+
+        out = StringIO()
+        call_command("post_weekly_playlist", "--dry-run", stdout=out)
+        output = out.getvalue()
+        self.assertIn(str(newer_playlist.id), output)


### PR DESCRIPTION
Closes #1

## Summary

- **New command** `post_weekly_playlist`: posts a weekly playlist as a flyer+QR carousel instead of styled cards
- **New image helpers** in `commons/instagram_images.py`:
  - `generate_qr_code()` — moved from `create_weekly_playlist_intro_video.py` to avoid duplication
  - `_resize_to_square(raw_bytes, size)` — center-crops arbitrary aspect-ratio flyer images to 1080×1080
  - `generate_qr_slide(url, position, performer_name, venue_name, event_name, event_date)` — 1080×1080 QR slide with metadata overlay
- **Carousel structure**: cover → per-performer (event flyer or `generate_performer_card()` fallback) + QR code slide
- **Arguments**: `--playlist-id` (optional, defaults to latest by date), `--platform instagram` (default), `--dry-run`, `--base-url`, `--max-performers` (default 4, max 4 to stay within 10-slide cap)
- **Platform dispatch** via `PLATFORM_HANDLERS` dict for future Threads support

## Test plan

- [x] 9 unit tests for `generate_qr_slide()` and `_resize_to_square()` (size, JPEG validity, edge cases)
- [x] 7 command tests: dry-run (no post), explicit playlist ID, caption content, slide count, invalid ID, slide cap enforcement, latest-playlist selection
- [x] All 16 tests pass
- [x] `ruff check` / `ruff format` — clean, pre-commit hooks pass