### PR TITLE
fix: migrate Instagram/Threads token cache from pickle to JSON

### DIFF
--- a/malcom/commons/instagram_utils.py
+++ b/malcom/commons/instagram_utils.py
@@ -12,7 +12,6 @@ Refresh any time after 24 hours of issuance and before 60-day expiry.
 """
 
 import logging
-import pickle
 import ssl
 import threading
 import webbrowser
@@ -177,15 +176,15 @@ def _load_token(cache_file: Path) -> InstagramToken | None:
     if not cache_file.exists():
         return None
     try:
-        return pickle.loads(cache_file.read_bytes())  # noqa: S301
+        return InstagramToken.model_validate_json(cache_file.read_text())
     except Exception as exc:  # noqa: BLE001
-        logger.warning(f"Failed to load Instagram token cache: {exc}")
+        logger.warning(f"Failed to load Instagram token cache ({type(exc).__name__}): {exc}")
         return None
 
 
 def _save_token(token: InstagramToken, cache_file: Path) -> None:
     try:
-        cache_file.write_bytes(pickle.dumps(token))
+        cache_file.write_text(token.model_dump_json())
         logger.info(f"Instagram token cached to {cache_file}")
     except Exception as exc:  # noqa: BLE001
         logger.warning(f"Failed to save Instagram token cache: {exc}")

--- a/malcom/commons/tests/test_token_cache.py
+++ b/malcom/commons/tests/test_token_cache.py
@@ -1,0 +1,133 @@
+"""Regression tests for JSON-based token cache serialization.
+
+Covers the round-trip for InstagramToken and ThreadsToken to ensure
+module renames cannot break deserialization (the pickle path was fragile).
+"""
+
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from django.test import TestCase
+
+from commons.instagram_utils import (
+    InstagramToken,
+    _load_token as _load_instagram_token,
+    _save_token as _save_instagram_token,
+)
+from commons.threads_utils import ThreadsToken, _load_token as _load_threads_token, _save_token as _save_threads_token
+
+
+def _make_instagram_token() -> InstagramToken:
+    now = datetime.now(tz=UTC)
+    return InstagramToken(
+        access_token="test-access-token",  # noqa: S106
+        user_id="123456789",
+        issued_at=now,
+        expires_at=now + timedelta(days=60),
+    )
+
+
+def _make_threads_token() -> ThreadsToken:
+    now = datetime.now(tz=UTC)
+    return ThreadsToken(
+        access_token="test-threads-token",  # noqa: S106
+        user_id="987654321",
+        issued_at=now,
+        expires_at=now + timedelta(days=60),
+    )
+
+
+class TestInstagramTokenCache(TestCase):
+    def test_save_and_load_roundtrip(self) -> None:
+        token = _make_instagram_token()
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            cache_file = Path(f.name)
+
+        try:
+            _save_instagram_token(token, cache_file)
+            loaded = _load_instagram_token(cache_file)
+
+            self.assertIsNotNone(loaded)
+            self.assertEqual(loaded.access_token, token.access_token)
+            self.assertEqual(loaded.user_id, token.user_id)
+            self.assertEqual(loaded.issued_at, token.issued_at)
+            self.assertEqual(loaded.expires_at, token.expires_at)
+        finally:
+            cache_file.unlink(missing_ok=True)
+
+    def test_load_returns_none_when_file_missing(self) -> None:
+        result = _load_instagram_token(Path("/tmp/nonexistent_instagram_token.json"))  # noqa: S108
+        self.assertIsNone(result)
+
+    def test_load_returns_none_on_invalid_json(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            f.write("not valid json {{{")
+            cache_file = Path(f.name)
+
+        try:
+            result = _load_instagram_token(cache_file)
+            self.assertIsNone(result)
+        finally:
+            cache_file.unlink(missing_ok=True)
+
+    def test_cache_file_is_json_not_pickle(self) -> None:
+        token = _make_instagram_token()
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            cache_file = Path(f.name)
+
+        try:
+            _save_instagram_token(token, cache_file)
+            content = cache_file.read_text()
+            # JSON starts with '{', pickle starts with b'\x80'
+            self.assertTrue(content.startswith("{"))
+            self.assertIn("access_token", content)
+        finally:
+            cache_file.unlink(missing_ok=True)
+
+
+class TestThreadsTokenCache(TestCase):
+    def test_save_and_load_roundtrip(self) -> None:
+        token = _make_threads_token()
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            cache_file = Path(f.name)
+
+        try:
+            _save_threads_token(token, cache_file)
+            loaded = _load_threads_token(cache_file)
+
+            self.assertIsNotNone(loaded)
+            self.assertEqual(loaded.access_token, token.access_token)
+            self.assertEqual(loaded.user_id, token.user_id)
+            self.assertEqual(loaded.issued_at, token.issued_at)
+            self.assertEqual(loaded.expires_at, token.expires_at)
+        finally:
+            cache_file.unlink(missing_ok=True)
+
+    def test_load_returns_none_when_file_missing(self) -> None:
+        result = _load_threads_token(Path("/tmp/nonexistent_threads_token.json"))  # noqa: S108
+        self.assertIsNone(result)
+
+    def test_load_returns_none_on_invalid_json(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            f.write("not valid json {{{")
+            cache_file = Path(f.name)
+
+        try:
+            result = _load_threads_token(cache_file)
+            self.assertIsNone(result)
+        finally:
+            cache_file.unlink(missing_ok=True)
+
+    def test_cache_file_is_json_not_pickle(self) -> None:
+        token = _make_threads_token()
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            cache_file = Path(f.name)
+
+        try:
+            _save_threads_token(token, cache_file)
+            content = cache_file.read_text()
+            self.assertTrue(content.startswith("{"))
+            self.assertIn("access_token", content)
+        finally:
+            cache_file.unlink(missing_ok=True)

--- a/malcom/commons/threads_utils.py
+++ b/malcom/commons/threads_utils.py
@@ -7,7 +7,6 @@ Refresh any time after 24 hours of issuance and before 60-day expiry.
 """
 
 import logging
-import pickle
 import ssl
 import threading
 import webbrowser
@@ -169,15 +168,15 @@ def _load_token(cache_file: Path) -> ThreadsToken | None:
     if not cache_file.exists():
         return None
     try:
-        return pickle.loads(cache_file.read_bytes())  # noqa: S301
+        return ThreadsToken.model_validate_json(cache_file.read_text())
     except Exception as exc:  # noqa: BLE001
-        logger.warning(f"Failed to load Threads token cache: {exc}")
+        logger.warning(f"Failed to load Threads token cache ({type(exc).__name__}): {exc}")
         return None
 
 
 def _save_token(token: ThreadsToken, cache_file: Path) -> None:
     try:
-        cache_file.write_bytes(pickle.dumps(token))
+        cache_file.write_text(token.model_dump_json())
         logger.info(f"Threads token cached to {cache_file}")
     except Exception as exc:  # noqa: BLE001
         logger.warning(f"Failed to save Threads token cache: {exc}")

--- a/malcom/houses/management/commands/authorize_social_accounts.py
+++ b/malcom/houses/management/commands/authorize_social_accounts.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             if not settings.INSTAGRAM_APP_ID or not settings.INSTAGRAM_APP_SECRET:
                 self.stderr.write("INSTAGRAM_APP_ID and INSTAGRAM_APP_SECRET must be set in .env")
                 return
-            token_cache = cert_file.parent / "instagram_token.pickle"
+            token_cache = cert_file.parent / "instagram_token.json"
             self.stdout.write("Starting Instagram OAuth flow — a browser window will open...")
             try:
                 token = get_instagram_token(cert_file, key_file, token_cache)
@@ -56,7 +56,7 @@ class Command(BaseCommand):
             if not settings.THREADS_APP_ID or not settings.THREADS_APP_SECRET:
                 self.stderr.write("THREADS_APP_ID and THREADS_APP_SECRET must be set in .env")
                 return
-            token_cache = cert_file.parent / "threads_token.pickle"
+            token_cache = cert_file.parent / "threads_token.json"
             self.stdout.write("Starting Threads OAuth flow — a browser window will open...")
             try:
                 token = get_threads_token(cert_file, key_file, token_cache)

--- a/malcom/houses/management/commands/post_monthly_playlist_instagram.py
+++ b/malcom/houses/management/commands/post_monthly_playlist_instagram.py
@@ -116,7 +116,7 @@ class Command(BaseCommand):
 
         cert_file = settings.OAUTH_LOCALHOST_CERT
         key_file = settings.OAUTH_LOCALHOST_KEY
-        token_cache = cert_file.parent / "instagram_token.pickle"
+        token_cache = cert_file.parent / "instagram_token.json"
 
         token = get_instagram_token(cert_file, key_file, token_cache)
         self.stdout.write("Instagram token loaded")

--- a/malcom/houses/management/commands/post_weekly_playlist.py
+++ b/malcom/houses/management/commands/post_weekly_playlist.py
@@ -43,7 +43,7 @@ def _post_instagram(
     cert_file: object,
     key_file: object,
 ) -> str:
-    token_cache = cert_file.parent / "instagram_token.pickle"
+    token_cache = cert_file.parent / "instagram_token.json"
     token = get_instagram_token(cert_file, key_file, token_cache)
     return post_carousel(user_id, token.access_token, images, caption)
 

--- a/malcom/houses/management/commands/post_weekly_playlist_instagram.py
+++ b/malcom/houses/management/commands/post_weekly_playlist_instagram.py
@@ -106,7 +106,7 @@ class Command(BaseCommand):
 
         cert_file = settings.OAUTH_LOCALHOST_CERT
         key_file = settings.OAUTH_LOCALHOST_KEY
-        token_cache = cert_file.parent / "instagram_token.pickle"
+        token_cache = cert_file.parent / "instagram_token.json"
 
         token = get_instagram_token(cert_file, key_file, token_cache)
         self.stdout.write("Instagram token loaded")


### PR DESCRIPTION
## Summary

- Replaces `pickle.dumps/loads` with `model_dump_json` / `model_validate_json` in `commons/instagram_utils.py` and `commons/threads_utils.py` — immune to future module renames
- Updates all management commands (`authorize_social_accounts`, `post_weekly_playlist`, `post_weekly_playlist_instagram`, `post_monthly_playlist_instagram`) to use `.json` cache file paths
- Improves `_load_token` error logging to include the exception type (e.g. `ModuleNotFoundError`, `ValidationError`) for easier diagnosis
- Removes `import pickle` and the `# noqa: S301` suppression from both utils
- Adds 8 regression tests covering round-trip serialization, missing-file, invalid-JSON, and format verification for both `InstagramToken` and `ThreadsToken`

**Operator action required after merge:** delete the stale `.pickle` files from the production host and re-authorize interactively:
```bash
rm ~/projects/hakoake-backend/instagram_token.pickle
rm ~/projects/hakoake-backend/threads_token.pickle  # if it exists
cd ~/projects/hakoake-backend/malcom
uv run python manage.py authorize_social_accounts --instagram --threads
```

## Test plan

- [x] `uv run poe test` — all tests pass (8 new + existing suite green)
- [x] `uv run ruff check` — no errors
- [x] Pre-commit hooks pass

Closes #20