### PR TITLE
fix: add Ollama pre-flight checks and fix playlist_db_id stdout pollution

### DIFF
--- a/scripts/hakoake-gen-video.sh
+++ b/scripts/hakoake-gen-video.sh
@@ -9,6 +9,15 @@ set -euo pipefail
 
 export PATH="/home/monkut/.local/bin:$PATH"
 
+# Load environment variables from .env
+ENV_FILE="$HOME/projects/hakoake-backend/.env"
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+fi
+
 HAKOAKE_DIR="$HOME/projects/hakoake-backend/malcom"
 LOG_DIR="$HOME/projects/hakoake-backend/logs"
 mkdir -p "$LOG_DIR"
@@ -20,12 +29,26 @@ LOGFILE="$LOG_DIR/hakoake-gen-video-${MONDAY}.log"
 # Tee all output (stdout + stderr) to a dated log file
 exec > >(tee "$LOGFILE") 2>&1
 
+# Pre-flight: verify Ollama service is reachable before proceeding
+echo "Checking Ollama service availability..."
+if ! curl -sf http://127.0.0.1:11434 > /dev/null; then
+    echo "ERROR: Ollama is not reachable at http://127.0.0.1:11434. Ensure ollama.service is running (systemctl start ollama)." >&2
+    exit 1
+fi
+echo "Ollama is reachable."
+
+# Pre-flight: ensure mistral-small model is pulled (matches settings.PLAYLIST_INTRO_TEXT_GENERATION_MODEL)
+echo "Ensuring mistral-small model is available..."
+ollama pull mistral-small
+
 echo "Creating weekly playlist for week starting ${MONDAY}..."
 cd "$HAKOAKE_DIR"
 uv run python manage.py create_weekly_playlist "$MONDAY"
 
 echo "Looking up playlist DB id for ${MONDAY}..."
-playlist_db_id=$(uv run python manage.py list_weekly_playlist "$MONDAY" --json | jq -r '.id')
+# grep '^{' filters out any Django startup messages (e.g. "N objects imported automatically")
+# that may be written to stdout before the JSON output
+playlist_db_id=$(uv run python manage.py list_weekly_playlist "$MONDAY" --json | grep '^{' | jq -r '.id')
 
 echo "Generating weekly playlist video for playlist id=${playlist_db_id}..."
 uv run python manage.py generate_weekly_playlist_video "$playlist_db_id"


### PR DESCRIPTION
## Summary

Fixes the `hakoake-gen-video` cron job failures documented in #2.

- **Pre-flight Ollama health check**: `curl -sf http://127.0.0.1:11434` runs before any playlist work. If Ollama is unreachable the script exits immediately with a clear error message instead of failing midway through after the YouTube playlist has already been created.
- **Pre-flight model pull**: `ollama pull mistral-small` runs before the generation step to ensure the model is present. This is idempotent — if already pulled it completes instantly.
- **Fix Django stdout pollution**: pipes `list_weekly_playlist --json` through `grep '^{'` before `jq` to discard any Django startup messages (e.g. "N objects imported automatically") that could corrupt `playlist_db_id`.

## Test plan

- [ ] Verify script exits immediately with "ERROR: Ollama is not reachable..." when `ollama.service` is stopped
- [ ] Verify `ollama pull mistral-small` runs silently when model is already present
- [ ] Verify `playlist_db_id` is extracted correctly even if Django startup messages appear on stdout
- [ ] Verify job succeeds end-to-end on next scheduled run (Monday 2026-04-13 ~22:00 JST)

Closes #2