### PR TITLE
fix: re-verify YouTube durations for legacy PerformerSong rows in weekly playlist

### DIFF
--- a/malcom/commons/tests/test_youtube_utils.py
+++ b/malcom/commons/tests/test_youtube_utils.py
@@ -3,7 +3,10 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import googleapiclient.errors
 from django.test import TestCase
+
+from commons.youtube_utils import get_video_durations, parse_iso8601_duration
 
 
 class TestUploadVideoToYoutube(TestCase):
@@ -125,3 +128,101 @@ class TestInsertVideoAtPosition(TestCase):
 
         call_body = mock_youtube.playlistItems.return_value.insert.call_args[1]["body"]
         self.assertEqual(call_body["snippet"]["position"], 3)
+
+
+class TestParseIso8601Duration(TestCase):
+    def test_minutes_and_seconds(self) -> None:
+        self.assertEqual(parse_iso8601_duration("PT4M37S"), 4 * 60 + 37)
+
+    def test_hours_minutes_seconds(self) -> None:
+        self.assertEqual(parse_iso8601_duration("PT1H2M3S"), 3600 + 120 + 3)
+
+    def test_seconds_only(self) -> None:
+        self.assertEqual(parse_iso8601_duration("PT30S"), 30)
+
+    def test_unparseable_returns_zero(self) -> None:
+        self.assertEqual(parse_iso8601_duration("LIVE"), 0)
+        self.assertEqual(parse_iso8601_duration(""), 0)
+        self.assertEqual(parse_iso8601_duration("not a duration"), 0)
+
+
+class TestGetVideoDurations(TestCase):
+    @patch("commons.youtube_utils.get_authorized_youtube_client")
+    def test_empty_input_returns_empty_dict_without_api_call(self, mock_get_client: MagicMock) -> None:
+        result = get_video_durations([], Path("/tmp/client_secret.json"))  # noqa: S108
+
+        self.assertEqual(result, {})
+        mock_get_client.assert_not_called()
+
+    @patch("commons.youtube_utils.get_authorized_youtube_client")
+    def test_returns_durations_for_listed_videos(self, mock_get_client: MagicMock) -> None:
+        mock_youtube = MagicMock()
+        mock_get_client.return_value = mock_youtube
+        mock_youtube.videos.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {"id": "vid_short", "contentDetails": {"duration": "PT3M22S"}},
+                {"id": "vid_long", "contentDetails": {"duration": "PT41M12S"}},
+            ]
+        }
+
+        result = get_video_durations(
+            ["vid_short", "vid_long"],
+            Path("/tmp/client_secret.json"),  # noqa: S108
+        )
+
+        self.assertEqual(result, {"vid_short": 3 * 60 + 22, "vid_long": 41 * 60 + 12})
+        mock_youtube.videos.return_value.list.assert_called_once_with(part="contentDetails", id="vid_short,vid_long")
+
+    @patch("commons.youtube_utils.get_authorized_youtube_client")
+    def test_unavailable_video_omitted_from_result(self, mock_get_client: MagicMock) -> None:
+        mock_youtube = MagicMock()
+        mock_get_client.return_value = mock_youtube
+        # Only one of two requested IDs comes back (the other is deleted/private)
+        mock_youtube.videos.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {"id": "vid_alive", "contentDetails": {"duration": "PT2M0S"}},
+            ]
+        }
+
+        result = get_video_durations(
+            ["vid_alive", "vid_dead"],
+            Path("/tmp/client_secret.json"),  # noqa: S108
+        )
+
+        self.assertEqual(result, {"vid_alive": 120})
+        self.assertNotIn("vid_dead", result)
+
+    @patch("commons.youtube_utils.get_authorized_youtube_client")
+    def test_batches_in_groups_of_50(self, mock_get_client: MagicMock) -> None:
+        mock_youtube = MagicMock()
+        mock_get_client.return_value = mock_youtube
+        # Return one item per requested ID per call
+        mock_youtube.videos.return_value.list.return_value.execute.side_effect = [
+            {"items": [{"id": f"vid{i}", "contentDetails": {"duration": "PT1M0S"}} for i in range(50)]},
+            {"items": [{"id": f"vid{i}", "contentDetails": {"duration": "PT1M0S"}} for i in range(50, 75)]},
+        ]
+
+        video_ids = [f"vid{i}" for i in range(75)]
+        result = get_video_durations(video_ids, Path("/tmp/client_secret.json"))  # noqa: S108
+
+        self.assertEqual(len(result), 75)
+        self.assertEqual(mock_youtube.videos.return_value.list.call_count, 2)
+
+    @patch("commons.youtube_utils.get_authorized_youtube_client")
+    def test_http_error_skips_batch_returns_partial(self, mock_get_client: MagicMock) -> None:
+        mock_youtube = MagicMock()
+        mock_get_client.return_value = mock_youtube
+
+        mock_resp = MagicMock()
+        mock_resp.status = 500
+        mock_resp.reason = "Server Error"
+        mock_youtube.videos.return_value.list.return_value.execute.side_effect = googleapiclient.errors.HttpError(
+            mock_resp, b"Server Error"
+        )
+
+        result = get_video_durations(
+            ["vid_a", "vid_b"],
+            Path("/tmp/client_secret.json"),  # noqa: S108
+        )
+
+        self.assertEqual(result, {})

--- a/malcom/commons/youtube_utils.py
+++ b/malcom/commons/youtube_utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import pickle
+import re
 from pathlib import Path
 
 import google_auth_oauthlib.flow
@@ -13,6 +14,23 @@ from google.auth.transport.requests import Request
 logger = logging.getLogger(__name__)
 
 DEFAULT_SCOPES = ["https://www.googleapis.com/auth/youtube.force-ssl"]
+VIDEOS_LIST_BATCH_SIZE = 50  # YouTube Data API videos.list max ids per call
+
+_ISO8601_DURATION_RE = re.compile(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?")
+
+
+def parse_iso8601_duration(duration: str) -> int:
+    """Parse a YouTube ISO 8601 duration (e.g. ``PT1H2M3S``) to total seconds.
+
+    Returns 0 if the string cannot be parsed.
+    """
+    match = _ISO8601_DURATION_RE.fullmatch(duration or "")
+    if not match:
+        return 0
+    hours = int(match.group(1) or 0)
+    minutes = int(match.group(2) or 0)
+    seconds = int(match.group(3) or 0)
+    return hours * 3600 + minutes * 60 + seconds
 
 
 def get_authorized_youtube_client(client_secrets_file: Path, scopes: list[str] | None = None):
@@ -128,6 +146,36 @@ def list_playlist_items(playlist_id: str, client_secrets_file: Path) -> list[dic
             break
     logger.info(f"Listed {len(items)} items in playlist {playlist_id}")
     return items
+
+
+def get_video_durations(video_ids: list[str], client_secrets_file: Path) -> dict[str, int]:
+    """Fetch actual durations (in seconds) for the given YouTube video IDs.
+
+    Returns a dict mapping ``video_id`` -> ``duration_seconds``. Videos that
+    are deleted, private, or otherwise unavailable will be omitted from the
+    result. Empty input returns an empty dict.
+
+    Batches IDs into groups of ``VIDEOS_LIST_BATCH_SIZE`` (the YouTube API
+    ``videos.list`` per-call maximum).
+    """
+    if not video_ids:
+        return {}
+
+    youtube = get_authorized_youtube_client(client_secrets_file)
+    durations: dict[str, int] = {}
+    for start in range(0, len(video_ids), VIDEOS_LIST_BATCH_SIZE):
+        batch = video_ids[start : start + VIDEOS_LIST_BATCH_SIZE]
+        try:
+            response = youtube.videos().list(part="contentDetails", id=",".join(batch)).execute()
+        except googleapiclient.errors.HttpError:
+            logger.exception(f"Failed to fetch durations for batch starting at index {start}")
+            continue
+        for item in response.get("items", []):
+            video_id = item["id"]
+            iso_duration = item.get("contentDetails", {}).get("duration", "")
+            durations[video_id] = parse_iso8601_duration(iso_duration)
+    logger.info(f"Fetched durations for {len(durations)}/{len(video_ids)} videos")
+    return durations
 
 
 def remove_playlist_item(playlist_item_id: str, client_secrets_file: Path) -> bool:

--- a/malcom/houses/management/commands/create_weekly_playlist.py
+++ b/malcom/houses/management/commands/create_weekly_playlist.py
@@ -17,11 +17,11 @@ This command:
 """
 
 import logging
-from datetime import timedelta
+from datetime import date, timedelta
 from pathlib import Path
 
 from commons.functions import parse_week
-from commons.youtube_utils import add_video_to_playlist, create_youtube_playlist
+from commons.youtube_utils import add_video_to_playlist, create_youtube_playlist, get_video_durations
 from django.conf import settings
 from django.core.management import BaseCommand, CommandParser
 from django.db import transaction
@@ -35,6 +35,15 @@ logger = logging.getLogger(__name__)
 
 # Constants
 DEFAULT_TOP_PERFORMERS_COUNT = 5
+
+# PerformerSong rows last touched before this date were ingested by an earlier
+# extraction path that occasionally stored stale ``youtube_duration_seconds``
+# values (see hakoake-backend playlist incident on 2026-04-06 where a 41-minute
+# live recording was stored as a short clip). For any candidate song whose
+# ``updated_datetime`` is before this cutoff we re-verify the actual duration
+# against the YouTube API before applying the playlist duration filter, then
+# bump ``updated_datetime`` so subsequent runs skip the row.
+DURATION_REVERIFICATION_CUTOFF_DATE = date(2026, 3, 30)
 
 
 class Command(BaseCommand):
@@ -64,6 +73,83 @@ class Command(BaseCommand):
             "--dry-run",
             action="store_true",
             help="Perform a dry run without creating playlist or updating weights",
+        )
+
+    def _reverify_legacy_song_durations(
+        self,
+        eligible_performers: list[Performer],
+        min_duration_seconds: int,
+        max_duration_seconds: int,
+        secrets_file: Path,
+    ) -> None:
+        """Re-verify YouTube durations for legacy candidate songs.
+
+        The candidate filter relies on ``auto_now`` having stamped
+        ``updated_datetime`` at last save: anything before
+        ``DURATION_REVERIFICATION_CUTOFF_DATE`` is treated as legacy. Every
+        processed row's ``updated_datetime`` is bumped (even when the duration
+        matched) so subsequent runs converge — once the legacy backlog drains,
+        this method becomes a no-op. Videos missing from the API response are
+        set to ``youtube_duration_seconds=0`` to exclude them downstream.
+        """
+        candidate_rows = list(
+            PerformerSong.objects.filter(
+                performer__in=eligible_performers,
+                updated_datetime__date__lt=DURATION_REVERIFICATION_CUTOFF_DATE,
+                youtube_video_id__isnull=False,
+                youtube_duration_seconds__gte=min_duration_seconds,
+                youtube_duration_seconds__lte=max_duration_seconds,
+            )
+            .exclude(youtube_video_id="")
+            .values_list("id", "youtube_video_id", "youtube_duration_seconds")
+        )
+
+        if not candidate_rows:
+            return
+
+        self.stdout.write(
+            f"Re-verifying YouTube durations for {len(candidate_rows)} legacy candidate song(s) "
+            f"(updated_datetime before {DURATION_REVERIFICATION_CUTOFF_DATE.isoformat()})..."
+        )
+
+        video_ids = [video_id for _, video_id, _ in candidate_rows]
+        actual_durations = get_video_durations(video_ids, secrets_file)
+
+        updates = 0
+        unavailable_ids: list[int] = []
+        unchanged_ids: list[int] = []
+        now = timezone.now()
+        for song_id, video_id, db_duration in candidate_rows:
+            actual = actual_durations.get(video_id)
+            if actual is None:
+                unavailable_ids.append(song_id)
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  song id={song_id} video={video_id} unavailable on YouTube; duration set to 0"
+                    )
+                )
+                continue
+            if actual != db_duration:
+                PerformerSong.objects.filter(pk=song_id).update(
+                    youtube_duration_seconds=actual,
+                    updated_datetime=now,
+                )
+                updates += 1
+                self.stdout.write(f"  song id={song_id} video={video_id} duration {db_duration}s -> {actual}s")
+            else:
+                unchanged_ids.append(song_id)
+
+        if unavailable_ids:
+            PerformerSong.objects.filter(pk__in=unavailable_ids).update(
+                youtube_duration_seconds=0,
+                updated_datetime=now,
+            )
+        if unchanged_ids:
+            PerformerSong.objects.filter(pk__in=unchanged_ids).update(updated_datetime=now)
+
+        self.stdout.write(
+            f"Re-verification complete: {updates} duration update(s), "
+            f"{len(unavailable_ids)} unavailable video(s), {len(unchanged_ids)} verified-unchanged"
         )
 
     def handle(self, *args, **options):  # noqa: ANN002, ANN003, C901, PLR0911, PLR0912, PLR0915
@@ -149,14 +235,24 @@ class Command(BaseCommand):
             )
             return
 
+        min_duration_seconds = settings.MIN_SONG_SELECTION_DURATION_SECONDS
+        max_duration_seconds = settings.MAX_SONG_SELECTION_DURATION_MINUTES * 60
+
+        # Re-verify legacy song durations before filtering. Out-of-range songs
+        # cannot be selected anyway, so we skip them to save API quota.
+        if not dry_run:
+            self._reverify_legacy_song_durations(
+                eligible_performers,
+                min_duration_seconds,
+                max_duration_seconds,
+                secrets_file,
+            )
+
         # Select performers with unique songs (deduplicate by video_id)
         # NOTE: Weekly playlists do NOT exclude songs from previous playlists
         # They rely purely on playlist_weight rotation for fair selection
         selected_songs = []
         used_video_ids = set()
-
-        min_duration_seconds = settings.MIN_SONG_SELECTION_DURATION_SECONDS
-        max_duration_seconds = settings.MAX_SONG_SELECTION_DURATION_MINUTES * 60
 
         for performer in eligible_performers:
             if len(selected_songs) >= top_n:

--- a/malcom/houses/tests/test_create_weekly_playlist_reverify.py
+++ b/malcom/houses/tests/test_create_weekly_playlist_reverify.py
@@ -1,0 +1,259 @@
+"""Tests for the ``_reverify_legacy_song_durations`` step in create_weekly_playlist.
+
+Context: a 41-minute live recording (the 流血ブリザード "Namba Rockets" entry that
+shipped in the 2026-04-06 weekly playlist) was stored with a stale, much smaller
+``youtube_duration_seconds`` value. The DB row had been written by an earlier
+ingestion path; subsequent extractions agreed on a longer duration but the row
+was never refreshed. The pre-pass added in this fix re-fetches durations for any
+candidate PerformerSong row whose ``updated_datetime`` is before
+``DURATION_REVERIFICATION_CUTOFF_DATE`` and rewrites the DB before the playlist
+duration filter is applied. Every processed row's ``updated_datetime`` is then
+bumped so subsequent runs skip the row.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+from django.test import TestCase
+from performers.models import Performer, PerformerSong
+
+from houses.management.commands.create_weekly_playlist import (
+    DURATION_REVERIFICATION_CUTOFF_DATE,
+    Command,
+)
+
+# Use settings-aware bounds (matches the command)
+MIN_S = settings.MIN_SONG_SELECTION_DURATION_SECONDS
+MAX_S = settings.MAX_SONG_SELECTION_DURATION_MINUTES * 60
+
+
+def _make_performer(name: str) -> Performer:
+    p = Performer(name=name, name_kana=name, name_romaji=name)
+    p._skip_image_fetch = True  # noqa: SLF001
+    p.save()
+    return p
+
+
+def _make_song(
+    performer: Performer,
+    *,
+    duration_seconds: int,
+    video_id: str,
+    created_datetime: datetime,
+    updated_datetime: datetime | None = None,
+) -> PerformerSong:
+    song = PerformerSong.objects.create(
+        performer=performer,
+        title=f"{video_id} ({duration_seconds}s)",
+        youtube_video_id=video_id,
+        youtube_url=f"https://www.youtube.com/watch?v={video_id}",
+        youtube_view_count=10000,
+        youtube_duration_seconds=duration_seconds,
+    )
+    # auto_now / auto_now_add bypass: rewrite both timestamps after insert.
+    # Defaults updated_datetime to created_datetime so the row is treated as
+    # legacy unless the test explicitly says otherwise.
+    if updated_datetime is None:
+        updated_datetime = created_datetime
+    PerformerSong.objects.filter(pk=song.pk).update(
+        created_datetime=created_datetime,
+        updated_datetime=updated_datetime,
+    )
+    song.refresh_from_db()
+    return song
+
+
+# Sentinel datetimes for legacy / fresh song rows
+_LEGACY_DATETIME = datetime.combine(
+    DURATION_REVERIFICATION_CUTOFF_DATE - timedelta(days=10),
+    datetime.min.time(),
+    tzinfo=UTC,
+)
+_FRESH_DATETIME = datetime.combine(
+    DURATION_REVERIFICATION_CUTOFF_DATE + timedelta(days=1),
+    datetime.min.time(),
+    tzinfo=UTC,
+)
+
+
+class TestReverifyLegacySongDurations(TestCase):
+    """Direct tests for ``Command._reverify_legacy_song_durations``."""
+
+    def setUp(self) -> None:
+        self.command = Command()
+        self.command.stdout = MagicMock()
+        self.performer = _make_performer("test_performer")
+        self.secrets_file = Path("/tmp/client_secret.json")  # noqa: S108
+
+    @patch("houses.management.commands.create_weekly_playlist.get_video_durations")
+    def test_legacy_song_with_stale_short_duration_updated_to_actual(self, mock_get_durations: MagicMock) -> None:
+        """A legacy song claiming 30s but actually 2472s (41:12) should be rewritten."""
+        actual_seconds = 41 * 60 + 12  # 2472, well above the 12-minute max
+        song = _make_song(
+            self.performer,
+            duration_seconds=30,
+            video_id="vid_legacy_long",
+            created_datetime=_LEGACY_DATETIME,
+        )
+        mock_get_durations.return_value = {"vid_legacy_long": actual_seconds}
+
+        self.command._reverify_legacy_song_durations(  # noqa: SLF001
+            [self.performer], MIN_S, MAX_S, self.secrets_file
+        )
+
+        song.refresh_from_db()
+        self.assertEqual(song.youtube_duration_seconds, actual_seconds)
+        # updated_datetime must have moved past the cutoff so the row is skipped next run
+        self.assertGreaterEqual(
+            song.updated_datetime.date(),
+            DURATION_REVERIFICATION_CUTOFF_DATE,
+        )
+        mock_get_durations.assert_called_once_with(["vid_legacy_long"], self.secrets_file)
+
+    @patch("houses.management.commands.create_weekly_playlist.get_video_durations")
+    def test_matching_duration_leaves_value_alone_but_bumps_updated_datetime(
+        self, mock_get_durations: MagicMock
+    ) -> None:
+        """If YouTube confirms the existing duration, the value is unchanged but
+        ``updated_datetime`` must still be bumped so subsequent runs skip the row.
+        """
+        song = _make_song(
+            self.performer,
+            duration_seconds=180,
+            video_id="vid_legacy_ok",
+            created_datetime=_LEGACY_DATETIME,
+        )
+        mock_get_durations.return_value = {"vid_legacy_ok": 180}
+
+        self.command._reverify_legacy_song_durations(  # noqa: SLF001
+            [self.performer], MIN_S, MAX_S, self.secrets_file
+        )
+
+        song.refresh_from_db()
+        self.assertEqual(song.youtube_duration_seconds, 180)
+        self.assertGreaterEqual(
+            song.updated_datetime.date(),
+            DURATION_REVERIFICATION_CUTOFF_DATE,
+        )
+
+    @patch("houses.management.commands.create_weekly_playlist.get_video_durations")
+    def test_song_with_recent_updated_datetime_skipped(self, mock_get_durations: MagicMock) -> None:
+        """A song whose ``updated_datetime`` is on/after the cutoff must NOT be
+        re-verified — this covers both freshly-ingested rows and rows that have
+        already been touched by a previous re-verification run.
+        """
+        _make_song(
+            self.performer,
+            duration_seconds=180,
+            video_id="vid_recently_touched",
+            created_datetime=_LEGACY_DATETIME,
+            updated_datetime=_FRESH_DATETIME,
+        )
+        mock_get_durations.return_value = {}
+
+        self.command._reverify_legacy_song_durations(  # noqa: SLF001
+            [self.performer], MIN_S, MAX_S, self.secrets_file
+        )
+
+        # No candidates → API must not be called
+        mock_get_durations.assert_not_called()
+
+    @patch("houses.management.commands.create_weekly_playlist.get_video_durations")
+    def test_second_run_is_idempotent(self, mock_get_durations: MagicMock) -> None:
+        """After a row has been re-verified once, a second run must NOT include it
+        in the candidate set (because the first run bumped ``updated_datetime``).
+        """
+        _make_song(
+            self.performer,
+            duration_seconds=180,
+            video_id="vid_legacy_idempotent",
+            created_datetime=_LEGACY_DATETIME,
+        )
+        mock_get_durations.return_value = {"vid_legacy_idempotent": 180}
+
+        # First run — should fetch
+        self.command._reverify_legacy_song_durations(  # noqa: SLF001
+            [self.performer], MIN_S, MAX_S, self.secrets_file
+        )
+        self.assertEqual(mock_get_durations.call_count, 1)
+
+        # Second run — row's updated_datetime is now past the cutoff, so the
+        # candidate query returns nothing and the API is NOT called again
+        self.command._reverify_legacy_song_durations(  # noqa: SLF001
+            [self.performer], MIN_S, MAX_S, self.secrets_file
+        )
+        self.assertEqual(mock_get_durations.call_count, 1)
+
+    @patch("houses.management.commands.create_weekly_playlist.get_video_durations")
+    def test_legacy_song_already_out_of_range_not_reverified(self, mock_get_durations: MagicMock) -> None:
+        """Songs already excluded by the duration filter cannot be selected, so we
+        do not waste API quota re-verifying them.
+        """
+        _make_song(
+            self.performer,
+            duration_seconds=MAX_S + 1,  # already too long
+            video_id="vid_legacy_too_long",
+            created_datetime=_LEGACY_DATETIME,
+        )
+        mock_get_durations.return_value = {}
+
+        self.command._reverify_legacy_song_durations(  # noqa: SLF001
+            [self.performer], MIN_S, MAX_S, self.secrets_file
+        )
+
+        mock_get_durations.assert_not_called()
+
+    @patch("houses.management.commands.create_weekly_playlist.get_video_durations")
+    def test_unavailable_video_marked_as_zero_duration(self, mock_get_durations: MagicMock) -> None:
+        """If YouTube no longer returns the video, set duration=0 so it's filtered out
+        and bump ``updated_datetime`` so the row is not re-checked next run.
+        """
+        song = _make_song(
+            self.performer,
+            duration_seconds=180,
+            video_id="vid_legacy_deleted",
+            created_datetime=_LEGACY_DATETIME,
+        )
+        mock_get_durations.return_value = {}  # video missing from API response
+
+        self.command._reverify_legacy_song_durations(  # noqa: SLF001
+            [self.performer], MIN_S, MAX_S, self.secrets_file
+        )
+
+        song.refresh_from_db()
+        self.assertEqual(song.youtube_duration_seconds, 0)
+        self.assertGreaterEqual(
+            song.updated_datetime.date(),
+            DURATION_REVERIFICATION_CUTOFF_DATE,
+        )
+
+    @patch("houses.management.commands.create_weekly_playlist.get_video_durations")
+    def test_multiple_legacy_songs_batch_in_one_call(self, mock_get_durations: MagicMock) -> None:
+        """All legacy candidates for eligible performers should be batched into a
+        single ``get_video_durations`` call.
+        """
+        ids = []
+        for i in range(3):
+            video_id = f"vid_legacy_{i}"
+            _make_song(
+                self.performer,
+                duration_seconds=120 + i,
+                video_id=video_id,
+                created_datetime=_LEGACY_DATETIME,
+            )
+            ids.append(video_id)
+        mock_get_durations.return_value = dict.fromkeys(ids, 200)
+
+        self.command._reverify_legacy_song_durations(  # noqa: SLF001
+            [self.performer], MIN_S, MAX_S, self.secrets_file
+        )
+
+        self.assertEqual(mock_get_durations.call_count, 1)
+        called_ids = mock_get_durations.call_args[0][0]
+        self.assertEqual(sorted(called_ids), sorted(ids))
+
+    def test_cutoff_date_is_2026_03_30(self) -> None:
+        """Anchor the cutoff date so accidental drift is caught by tests."""
+        self.assertEqual(DURATION_REVERIFICATION_CUTOFF_DATE, date(2026, 3, 30))

--- a/malcom/performers/management/commands/validate_youtube_sociallinks.py
+++ b/malcom/performers/management/commands/validate_youtube_sociallinks.py
@@ -1,10 +1,9 @@
 import datetime
 import logging
-import re
 import time
 from pathlib import Path
 
-from commons.youtube_utils import get_authorized_youtube_client
+from commons.youtube_utils import get_authorized_youtube_client, parse_iso8601_duration
 from django.core.management.base import BaseCommand, CommandParser
 from django.utils import timezone
 
@@ -16,17 +15,6 @@ logger = logging.getLogger(__name__)
 YOUTUBE_READONLY_SCOPES = ["https://www.googleapis.com/auth/youtube.readonly"]
 BATCH_SIZE = 50
 VIDEO_COUNT_THRESHOLD = 10
-
-
-def parse_iso8601_duration(duration: str) -> int:
-    """Parse ISO 8601 duration (PT1H2M3S) to seconds."""
-    match = re.match(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?", duration)
-    if not match:
-        return 0
-    hours = int(match.group(1) or 0)
-    minutes = int(match.group(2) or 0)
-    seconds = int(match.group(3) or 0)
-    return hours * 3600 + minutes * 60 + seconds
 
 
 def name_matches(performer_name: str, channel_title: str, channel_description: str) -> bool:


### PR DESCRIPTION
## Summary

The 2026-04-06 weekly playlist selected a 41-minute live recording (流血ブリザード "Namba Rockets") because the DB row carried a stale `youtube_duration_seconds=30` from an earlier ingestion path — the duration filter let it through.

This adds a re-verification pre-pass that catches stale durations on legacy rows before the duration filter runs, and is self-extinguishing as the legacy backlog drains.

## Changes

- **`create_weekly_playlist`**: New `_reverify_legacy_song_durations` pre-pass. For any candidate `PerformerSong` whose `updated_datetime` predates `DURATION_REVERIFICATION_CUTOFF_DATE` (2026-03-30), re-fetch the actual duration from the YouTube API and rewrite the DB row before the per-performer selection runs. Videos missing from the API response are set to `duration=0` so the downstream filter excludes them.
- Every processed row's `updated_datetime` is bumped (even verified-unchanged) so the next run skips it. The pre-pass becomes a no-op once the legacy backlog drains.
- Homogeneous unavailable/unchanged UPDATEs are batched into single queries; per-row UPDATE is kept only for the rare "duration changed" branch.
- **`commons/youtube_utils`**: Extract `parse_iso8601_duration` from `validate_youtube_sociallinks` and add a new batched `get_video_durations` helper (groups of 50, the YouTube `videos.list` per-call max).
- **`validate_youtube_sociallinks`**: Drop the duplicate `parse_iso8601_duration`; import from `commons.youtube_utils`.

## Test plan

- [x] `python manage.py test houses.tests.test_create_weekly_playlist_reverify --debug-mode` — 8/8 passing, including idempotency test that confirms a second run makes zero API calls
- [x] `python manage.py test houses.tests --debug-mode` — full houses suite 152/152 passing
- [x] `python manage.py test commons.tests.test_youtube_utils --debug-mode` — new `TestParseIso8601Duration` and `TestGetVideoDurations` classes pass
- [x] `ruff check` and `ruff format` clean on all modified files
- [ ] After merge: monitor the next weekly playlist run for the re-verification log line `Re-verifying YouTube durations for N legacy candidate song(s)...` and confirm N drains to 0 over subsequent runs