### PR TITLE
feat: combine flyer and QR code into a single slide per performer

### DIFF
--- a/malcom/commons/instagram_images.py
+++ b/malcom/commons/instagram_images.py
@@ -444,3 +444,94 @@ def generate_qr_slide(
     )
 
     return _to_jpeg(img)
+
+
+def generate_combined_flyer_qr_slide(
+    flyer_bytes: bytes,
+    url: str,
+    position: int,
+    performer_name: str,
+    venue_name: str,
+    event_name: str,
+    event_date: date,
+) -> bytes:
+    """Generate a combined flyer + QR code slide. Returns JPEG bytes.
+
+    The flyer image fills the background. A QR code with metadata is overlaid
+    in the bottom-right quadrant on a semi-transparent panel. The position badge
+    sits in the top-left corner.
+
+    Args:
+        flyer_bytes: Raw flyer image bytes (JPEG/PNG)
+        url: QR code target URL
+        position: Performer position index in the playlist
+        performer_name: Performer name
+        venue_name: Live house name
+        event_name: PerformanceSchedule.performance_name
+        event_date: PerformanceSchedule.performance_date
+    """
+    # --- Background: flyer image scaled to fill ---
+    flyer_img = Image.open(io.BytesIO(flyer_bytes)).convert("RGB")
+    img = _scale_to_fill(flyer_img)
+
+    # --- Top accent bar ---
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([(0, 0), (IMG_W, 6)], fill=ACCENT_COLOR)
+
+    # --- Position badge (top-left) ---
+    draw.ellipse([(30, 20), (30 + 60, 20 + 60)], fill=ACCENT_COLOR)
+    draw.text((60, 50), str(position), font=_font(32, bold=True), fill=TEXT_COLOR, anchor="mm")
+
+    # --- QR overlay panel (bottom portion) ---
+    panel_h = 320
+    panel_y = IMG_H - panel_h
+    panel = Image.new("RGBA", (IMG_W, panel_h), (20, 20, 30, 210))
+    img_rgba = img.convert("RGBA")
+    img_rgba.paste(panel, (0, panel_y), panel)
+    img = img_rgba.convert("RGB")
+    draw = ImageDraw.Draw(img)
+
+    # QR code (left side of panel)
+    qr_size = 250
+    qr_img = generate_qr_code(url, qr_size)
+    qr_x = 40
+    qr_y = panel_y + (panel_h - qr_size) // 2
+    img.paste(qr_img, (qr_x, qr_y))
+
+    # Metadata (right side of panel, next to QR)
+    text_x = qr_x + qr_size + 30
+    text_y = panel_y + 24
+
+    # Performer name
+    font_name = _font(38, bold=True)
+    draw.text((text_x, text_y), performer_name, font=font_name, fill=TEXT_COLOR, anchor="lt")
+    text_y += 48
+
+    # Venue
+    font_detail = _font(28)
+    draw.text((text_x, text_y), venue_name, font=font_detail, fill=SECONDARY_COLOR, anchor="lt")
+    text_y += 38
+
+    # Event name (if set)
+    if event_name:
+        font_event = _font(24)
+        max_text_w = IMG_W - text_x - 30
+        lines = _text_wrapped(draw, event_name, font_event, max_text_w)
+        for line in lines[:2]:
+            draw.text((text_x, text_y), line, font=font_event, fill=DIM_COLOR, anchor="lt")
+            text_y += 32
+
+    # Event date
+    font_date = _font(30, bold=True)
+    draw.text(
+        (text_x, text_y),
+        event_date.strftime("%Y-%m-%d (%a)"),
+        font=font_date,
+        fill=ACCENT_COLOR,
+        anchor="lt",
+    )
+
+    # --- Bottom accent bar ---
+    draw.rectangle([(0, IMG_H - 6), (IMG_W, IMG_H)], fill=ACCENT_COLOR)
+
+    return _to_jpeg(img)

--- a/malcom/commons/tests/test_instagram_images.py
+++ b/malcom/commons/tests/test_instagram_images.py
@@ -1,14 +1,17 @@
-"""Tests for the Instagram image generator's font handling.
+"""Tests for the Instagram image generator's font handling and combined slide generation.
 
 The historical bug: instagram_images.py hardcoded DejaVu Sans, which has zero
 Japanese coverage, so every kana/kanji rendered as .notdef tofu boxes. These
 tests assert that Japanese glyphs render with real (non-notdef) widths.
 """
 
+import io
+from datetime import date
+
 from django.test import TestCase
 from PIL import Image, ImageDraw, ImageFont
 
-from commons.instagram_images import _font
+from commons.instagram_images import IMG_H, IMG_W, _font, generate_combined_flyer_qr_slide
 
 JAPANESE_SAMPLE = "残響のリフレイン"
 LATIN_SAMPLE = "HAKKO-AKKEI"
@@ -58,3 +61,60 @@ class TestFontFallback(TestCase):
         regular = _font(40, bold=False)
         self.assertIsNotNone(bold)
         self.assertIsNotNone(regular)
+
+
+def _make_dummy_flyer_bytes() -> bytes:
+    """Create a minimal JPEG image to use as a flyer input."""
+    img = Image.new("RGB", (800, 600), (100, 50, 150))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=85)
+    return buf.getvalue()
+
+
+class TestCombinedFlyerQrSlide(TestCase):
+    def test_returns_valid_jpeg(self) -> None:
+        """The combined slide must return loadable JPEG bytes."""
+        result = generate_combined_flyer_qr_slide(
+            flyer_bytes=_make_dummy_flyer_bytes(),
+            url="https://example.com/event/1",
+            position=3,
+            performer_name="残響のリフレイン",
+            venue_name="下北沢SHELTER",
+            event_name="Spring Live 2026",
+            event_date=date(2026, 4, 15),
+        )
+        self.assertIsInstance(result, bytes)
+        self.assertGreater(len(result), 1000)
+        img = Image.open(io.BytesIO(result))
+        self.assertEqual(img.size, (IMG_W, IMG_H))
+
+    def test_renders_without_event_name(self) -> None:
+        """Combined slide must not crash when event_name is empty."""
+        result = generate_combined_flyer_qr_slide(
+            flyer_bytes=_make_dummy_flyer_bytes(),
+            url="https://example.com",
+            position=1,
+            performer_name="TestBand",
+            venue_name="Shibuya WWW",
+            event_name="",
+            event_date=date(2026, 4, 10),
+        )
+        self.assertIsInstance(result, bytes)
+        self.assertGreater(len(result), 1000)
+
+    def test_renders_with_non_square_flyer(self) -> None:
+        """Non-square flyer images should be scaled/cropped to 1080x1080."""
+        wide_img = Image.new("RGB", (1920, 1080), (200, 100, 50))
+        buf = io.BytesIO()
+        wide_img.save(buf, format="JPEG")
+        result = generate_combined_flyer_qr_slide(
+            flyer_bytes=buf.getvalue(),
+            url="https://example.com",
+            position=5,
+            performer_name="WideImage Band",
+            venue_name="Shinjuku LOFT",
+            event_name="Wide Show",
+            event_date=date(2026, 5, 1),
+        )
+        img = Image.open(io.BytesIO(result))
+        self.assertEqual(img.size, (IMG_W, IMG_H))

--- a/malcom/houses/management/commands/post_weekly_playlist.py
+++ b/malcom/houses/management/commands/post_weekly_playlist.py
@@ -1,9 +1,11 @@
 """Post a weekly playlist announcement as a carousel.
 
 Carousel structure:
-  Slide 1      — cover: numbered performer list for the week
-  Slides 2k    — per-performer: event flyer image (or performer card fallback)
-  Slides 2k+1  — per-performer: QR code slide with metadata
+  Slide 1    — cover: numbered performer list for the week
+  Slides 2-N — per-performer: combined flyer + QR code overlay
+
+With 1 cover + 1 slide per performer, up to 9 performers fit in
+Instagram's 10-slide carousel limit.
 
 Usage:
     uv run python manage.py post_weekly_playlist
@@ -20,9 +22,9 @@ from datetime import timedelta
 from commons.instagram_images import (
     INSTAGRAM_HASHTAGS,
     _resize_to_square,
+    generate_combined_flyer_qr_slide,
     generate_performer_card,
     generate_playlist_cover,
-    generate_qr_slide,
 )
 from commons.instagram_post import build_caption, post_carousel
 from commons.instagram_utils import get_instagram_token
@@ -114,13 +116,12 @@ class Command(BaseCommand):
             self.stderr.write(self.style.ERROR("Playlist has no entries"))
             return
 
-        # The cover slide lists every performer (limited only by what fits visually);
-        # the per-performer flyer + QR pairs are truncated to stay under the IG carousel cap.
-        max_performers = (MAX_CAROUSEL_SLIDES - 1) // 2
+        # 1 cover + 1 combined slide per performer = max (MAX_CAROUSEL_SLIDES - 1) performers
+        max_performers = MAX_CAROUSEL_SLIDES - 1
         entries = all_entries[:max_performers]
         if len(all_entries) > max_performers:
             logger.warning(
-                "Playlist has %d entries; only first %d get flyer/QR slides (cover lists all) "
+                "Playlist has %d entries; only first %d get slides (cover lists all) "
                 "to stay within %d-slide carousel limit",
                 len(all_entries),
                 max_performers,
@@ -157,7 +158,7 @@ class Command(BaseCommand):
         self.stdout.write(f"Generated cover image ({len(cover_bytes):,} bytes)")
         images: list[tuple[bytes, str]] = [(cover_bytes, "cover.jpg")]
 
-        # --- Per-performer slides ---
+        # --- Per-performer combined slides (flyer + QR overlay) ---
         for entry in entries:
             performer = entry.song.performer
             pos = entry.position
@@ -173,7 +174,7 @@ class Command(BaseCommand):
                 .first()
             )
 
-            # Flyer slide
+            # Get flyer image bytes (event image or generated performer card)
             if schedule and schedule.event_image and schedule.event_image.name:
                 try:
                     with schedule.event_image.open("rb") as f:
@@ -199,17 +200,14 @@ class Command(BaseCommand):
                 )
                 flyer_bytes = generate_performer_card(performer, pos, all_schedules)
 
-            flyer_filename = f"flyer_{pos:02d}_{performer.name[:20].replace(' ', '_')}.jpg"
-            images.append((flyer_bytes, flyer_filename))
-            self.stdout.write(f"Generated flyer for {performer.name} ({len(flyer_bytes):,} bytes)")
-
-            # QR code slide
+            # Combine flyer + QR into a single slide
             qr_url = _get_qr_url(schedule)
             venue_name = schedule.live_house.name if schedule else ""
             event_name = schedule.performance_name if schedule else ""
             event_date = schedule.performance_date if schedule else week_start
 
-            qr_bytes = generate_qr_slide(
+            combined_bytes = generate_combined_flyer_qr_slide(
+                flyer_bytes=flyer_bytes,
                 url=qr_url,
                 position=pos,
                 performer_name=performer.name,
@@ -217,9 +215,9 @@ class Command(BaseCommand):
                 event_name=event_name,
                 event_date=event_date,
             )
-            qr_filename = f"qr_{pos:02d}_{performer.name[:20].replace(' ', '_')}.jpg"
-            images.append((qr_bytes, qr_filename))
-            self.stdout.write(f"Generated QR slide for {performer.name} ({len(qr_bytes):,} bytes)")
+            filename = f"slide_{pos:02d}_{performer.name[:20].replace(' ', '_')}.jpg"
+            images.append((combined_bytes, filename))
+            self.stdout.write(f"Generated combined slide for {performer.name} ({len(combined_bytes):,} bytes)")
 
         self.stdout.write(f"Total slides: {len(images)}")
 

--- a/malcom/houses/tests/test_post_weekly_playlist.py
+++ b/malcom/houses/tests/test_post_weekly_playlist.py
@@ -79,15 +79,15 @@ class TestPostWeeklyPlaylistCommand(TestCase):
         self.assertIn("not found", err.getvalue())
 
     def test_truncates_to_max_when_entries_exceed_limit(self) -> None:
-        # Add enough entries to exceed the 4-performer carousel cap
-        for i in range(2, 7):
+        # Add enough entries to exceed the 9-performer carousel cap (1 cover + 9 combined = 10)
+        for i in range(2, 12):
             song = _make_song(self.performer, title=f"Extra Song {i}", video_id=f"extra{i}")
             WeeklyPlaylistEntry.objects.create(playlist=self.playlist, song=song, position=i)
 
         out = StringIO()
         with self.assertLogs("houses.management.commands.post_weekly_playlist", level="WARNING") as cm:
             call_command("post_weekly_playlist", "--dry-run", stdout=out)
-        self.assertTrue(any("only first" in msg and "flyer/QR slides" in msg for msg in cm.output))
+        self.assertTrue(any("only first" in msg and "slides" in msg for msg in cm.output))
 
     def test_uses_latest_playlist_when_no_id_given(self) -> None:
         newer_playlist = WeeklyPlaylist.objects.create(


### PR DESCRIPTION
## Summary

- Add `generate_combined_flyer_qr_slide()` — composites the flyer image as background with a QR code + metadata overlay panel at the bottom
- Update `post_weekly_playlist` command to produce 1 combined slide per performer instead of 2 separate slides (flyer + QR)
- Increase `max_performers` from 4 to 9 (1 cover + 9 combined = 10 slides, Instagram's carousel cap)
- Cover slide still lists all playlist entries regardless of truncation

## Test plan

- [x] New tests: combined slide returns valid 1080x1080 JPEG, handles empty event_name, handles non-square flyer input
- [x] Updated truncation test uses 11 entries (exceeds new 9-performer cap)
- [x] All 331 tests pass
- [ ] Dry-run end-to-end and visually inspect a generated combined slide
- [ ] Re-post the weekly playlist after merge

## Dependencies

Depends on #29 (PR for #27 — CJK font fallback) being merged first. This branch is based on that branch.

Closes #28