### PR TITLE
fix: pass --env-file to uv run in hakoake-gen-video.sh

### DIFF
--- a/scripts/hakoake-gen-video.sh
+++ b/scripts/hakoake-gen-video.sh
@@ -20,17 +20,19 @@ LOGFILE="$LOG_DIR/hakoake-gen-video-${MONDAY}.log"
 # Tee all output (stdout + stderr) to a dated log file
 exec > >(tee "$LOGFILE") 2>&1
 
+ENV_FILE="$HOME/projects/hakoake-backend/.env"
+
 echo "Creating weekly playlist for week starting ${MONDAY}..."
 cd "$HAKOAKE_DIR"
-uv run python manage.py create_weekly_playlist "$MONDAY"
+uv run --env-file "$ENV_FILE" python manage.py create_weekly_playlist "$MONDAY"
 
 echo "Looking up playlist DB id for ${MONDAY}..."
-playlist_db_id=$(uv run python manage.py list_weekly_playlist "$MONDAY" --json | jq -r '.id')
+playlist_db_id=$(uv run --env-file "$ENV_FILE" python manage.py list_weekly_playlist "$MONDAY" --json | jq -r '.id')
 
 echo "Generating weekly playlist video for playlist id=${playlist_db_id}..."
-uv run python manage.py generate_weekly_playlist_video "$playlist_db_id"
+uv run --env-file "$ENV_FILE" python manage.py generate_weekly_playlist_video "$playlist_db_id"
 
 echo "Posting weekly playlist announcement to Instagram..."
-uv run python manage.py post_weekly_playlist --playlist-id="$playlist_db_id"
+uv run --env-file "$ENV_FILE" python manage.py post_weekly_playlist --playlist-id="$playlist_db_id"
 
 echo "Done."


### PR DESCRIPTION
## Summary

- `hakoake-gen-video.sh` runs `uv run` from the `malcom/` subdirectory, but `.env` lives in the project root — env vars (including `INSTAGRAM_USER_ID`) were silently not loaded
- Added `--env-file "$HOME/projects/hakoake-backend/.env"` to all `uv run` invocations in the script

## Context

On 2026-04-06 the cron job failed at `generate_weekly_playlist_video` (Ollama not running), then on re-run the Instagram post silently aborted with "INSTAGRAM_USER_ID not set in .env" because the env file was never loaded. The Instagram weekly post for week 2026-04-06 was manually re-run successfully after applying this fix.