### PR TITLE
fix: make weekly playlist pipeline idempotent (#42)

### DIFF
--- a/malcom/houses/management/commands/create_weekly_playlist.py
+++ b/malcom/houses/management/commands/create_weekly_playlist.py
@@ -326,6 +326,22 @@ class Command(BaseCommand):
             self.stderr.write(self.style.ERROR(f"Failed to create YouTube playlist: {e}"))
             return
 
+        # Persist the WeeklyPlaylist record immediately after the YouTube playlist
+        # is created. This narrows the orphan-window: if the process is killed
+        # during the per-song add loop below, the existence guard at the top of
+        # handle() will short-circuit on re-run instead of creating a second
+        # YouTube playlist.
+        youtube_playlist_url = f"https://www.youtube.com/playlist?list={youtube_playlist_id}"
+        channel_url = getattr(settings, "YOUTUBE_CHANNEL_URL", "")
+        with transaction.atomic():
+            weekly_playlist = WeeklyPlaylist.objects.create(
+                date=target_date,
+                youtube_playlist_id=youtube_playlist_id,
+                youtube_playlist_url=youtube_playlist_url,
+                youtube_channel_url=channel_url,
+            )
+        self.stdout.write(f"\nCreated WeeklyPlaylist for week starting {target_date.strftime('%Y-%m-%d')}")
+
         # Add songs to YouTube playlist (deduplicate by video_id)
         added_songs = []
         added_video_ids = set()
@@ -344,20 +360,9 @@ class Command(BaseCommand):
             self.stderr.write(self.style.ERROR("Failed to add any songs to YouTube playlist"))
             return
 
-        # Create database records and update playlist_weight
+        # Create entry records and update playlist_weight atomically so a partial
+        # failure does not leave half-populated entries.
         with transaction.atomic():
-            # Create WeeklyPlaylist
-            youtube_playlist_url = f"https://www.youtube.com/playlist?list={youtube_playlist_id}"
-            channel_url = getattr(settings, "YOUTUBE_CHANNEL_URL", "")
-
-            weekly_playlist = WeeklyPlaylist.objects.create(
-                date=target_date,
-                youtube_playlist_id=youtube_playlist_id,
-                youtube_playlist_url=youtube_playlist_url,
-                youtube_channel_url=channel_url,
-            )
-            self.stdout.write(f"\nCreated WeeklyPlaylist for week starting {target_date.strftime('%Y-%m-%d')}")
-
             # Create WeeklyPlaylistEntry records
             for position, (performer, song) in enumerate(added_songs, start=1):
                 WeeklyPlaylistEntry.objects.create(

--- a/malcom/houses/management/commands/generate_weekly_playlist_video.py
+++ b/malcom/houses/management/commands/generate_weekly_playlist_video.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from commons.youtube_utils import insert_video_at_position, upload_video_to_youtube
 from django.core.management.base import BaseCommand, CommandParser
+from django.utils import timezone
 from houses.functions import generate_weekly_playlist_video
 from houses.models import WeeklyPlaylist
 
@@ -33,13 +34,19 @@ class Command(BaseCommand):
             action="store_true",
             help="Skip uploading the video to YouTube and inserting it into the playlist",
         )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Bypass idempotency guards and re-render/re-upload/re-insert the intro video",
+        )
 
-    def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003, PLR0911
+    def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003, C901, PLR0911, PLR0912, PLR0915
         """Generate and save playlist introduction video."""
         playlist_id = options["playlist_id"]
         intro_text_file = options.get("intro_text_file")
         secrets_file = Path(options["secrets_file"])
         skip_update_playlist = options["skip_update_playlist"]
+        force = options["force"]
 
         try:
             playlist = WeeklyPlaylist.objects.get(id=playlist_id)
@@ -49,6 +56,58 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Generating video for playlist: week of {playlist.date.strftime('%Y-%m-%d')}")
         self.stdout.write(f"Playlist URL: {playlist.youtube_playlist_url}")
+
+        # Idempotency branches — only relevant when we would otherwise upload/insert.
+        if not skip_update_playlist and not force:
+            if playlist.intro_youtube_video_id and playlist.intro_video_inserted_datetime:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Intro video already uploaded and inserted "
+                        f"(video_id={playlist.intro_youtube_video_id}); skipping. "
+                        f"Pass --force to re-render."
+                    )
+                )
+                return
+
+            if playlist.intro_youtube_video_id and not playlist.intro_video_inserted_datetime:
+                if not playlist.youtube_playlist_id:
+                    self.stderr.write(self.style.ERROR("Playlist has no youtube_playlist_id — cannot insert"))
+                    return
+                if not secrets_file.exists():
+                    self.stderr.write(self.style.ERROR(f"Secrets file not found: {secrets_file}"))
+                    return
+                self.stdout.write(
+                    f"Intro video already uploaded (video_id={playlist.intro_youtube_video_id}); "
+                    f"retrying insert at position 0 only."
+                )
+                success = insert_video_at_position(
+                    playlist.youtube_playlist_id, playlist.intro_youtube_video_id, 0, secrets_file
+                )
+                if success:
+                    playlist.intro_video_inserted_datetime = timezone.now()
+                    playlist.save(update_fields=["intro_video_inserted_datetime"])
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"Inserted intro video as first playlist entry: "
+                            f"https://youtu.be/{playlist.intro_youtube_video_id}"
+                        )
+                    )
+                else:
+                    self.stderr.write(self.style.ERROR("Failed to insert video into playlist"))
+                return
+
+        # --force: clear previously persisted intro state before re-rendering.
+        if force and (playlist.intro_youtube_video_id or playlist.intro_video_inserted_datetime):
+            self.stdout.write(
+                self.style.WARNING(
+                    f"--force: clearing previously stored intro video state "
+                    f"(previous video_id={playlist.intro_youtube_video_id!r}). "
+                    f"The old YouTube video is not deleted automatically."
+                )
+            )
+            playlist.intro_youtube_video_id = ""
+            playlist.intro_video_inserted_datetime = None
+            playlist.save(update_fields=["intro_youtube_video_id", "intro_video_inserted_datetime"])
 
         # Load introduction text from file if provided
         intro_text = None
@@ -100,12 +159,18 @@ class Command(BaseCommand):
             self.stderr.write(self.style.ERROR(f"Failed to upload video: {exc}"))
             return
 
+        # Persist upload result immediately so a later crash cannot cause a re-upload.
+        playlist.intro_youtube_video_id = video_id
+        playlist.save(update_fields=["intro_youtube_video_id"])
+
         self.stdout.write(f"Uploaded video ID: {video_id}")
 
         # Insert as first entry in the playlist
         self.stdout.write(f"Inserting video at position 0 in playlist {playlist.youtube_playlist_id}...")
         success = insert_video_at_position(playlist.youtube_playlist_id, video_id, 0, secrets_file)
         if success:
+            playlist.intro_video_inserted_datetime = timezone.now()
+            playlist.save(update_fields=["intro_video_inserted_datetime"])
             self.stdout.write(
                 self.style.SUCCESS(f"Inserted intro video as first playlist entry: https://youtu.be/{video_id}")
             )

--- a/malcom/houses/management/commands/post_weekly_playlist.py
+++ b/malcom/houses/management/commands/post_weekly_playlist.py
@@ -90,11 +90,17 @@ class Command(BaseCommand):
             action="store_true",
             help="Log images and caption without posting",
         )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Bypass the instagram_post_id guard and re-post even if already posted",
+        )
 
-    def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003, PLR0912, PLR0915
+    def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003, C901, PLR0912, PLR0915
         playlist_id: int | None = options["playlist_id"]
         platform: str = options["platform"]
         dry_run: bool = options["dry_run"]
+        force: bool = options["force"]
 
         # --- Resolve playlist ---
         if playlist_id:
@@ -108,6 +114,16 @@ class Command(BaseCommand):
             if not playlist:
                 self.stderr.write(self.style.ERROR("No WeeklyPlaylist found"))
                 return
+
+        # Idempotency guard — skip when IG post already exists (unless forced or a dry-run).
+        if playlist.instagram_post_id and not dry_run and not force:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Playlist {playlist.id} already posted to instagram "
+                    f"(post_id={playlist.instagram_post_id}); skipping. Pass --force to re-post."
+                )
+            )
+            return
 
         all_entries = list(
             WeeklyPlaylistEntry.objects.filter(playlist=playlist).order_by("position").select_related("song__performer")
@@ -234,4 +250,8 @@ class Command(BaseCommand):
         key_file = settings.OAUTH_LOCALHOST_KEY
         handler = PLATFORM_HANDLERS[platform]
         post_id = handler(settings.INSTAGRAM_USER_ID, images, caption, cert_file, key_file)
+        # Persist immediately so a later crash cannot cause a re-post.
+        if platform == "instagram":
+            playlist.instagram_post_id = post_id
+            playlist.save(update_fields=["instagram_post_id"])
         self.stdout.write(self.style.SUCCESS(f"Posted to {platform}: post_id={post_id}"))

--- a/malcom/houses/migrations/0012_weeklyplaylist_idempotency_fields.py
+++ b/malcom/houses/migrations/0012_weeklyplaylist_idempotency_fields.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("houses", "0011_performanceschedule_event_image"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="weeklyplaylist",
+            name="intro_youtube_video_id",
+            field=models.CharField(blank=True, default="", max_length=100),
+        ),
+        migrations.AddField(
+            model_name="weeklyplaylist",
+            name="intro_video_inserted_datetime",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="weeklyplaylist",
+            name="instagram_post_id",
+            field=models.CharField(blank=True, default="", max_length=100),
+        ),
+    ]

--- a/malcom/houses/models.py
+++ b/malcom/houses/models.py
@@ -151,6 +151,9 @@ class WeeklyPlaylist(TimestampedModel):
     youtube_playlist_id = models.CharField(max_length=100, blank=True, default="")
     youtube_playlist_url = models.URLField(max_length=500, blank=True, default="")
     youtube_channel_url = models.URLField(max_length=500, blank=True, default="")
+    intro_youtube_video_id = models.CharField(max_length=100, blank=True, default="")
+    intro_video_inserted_datetime = models.DateTimeField(null=True, blank=True)
+    instagram_post_id = models.CharField(max_length=100, blank=True, default="")
 
 
 class WeeklyPlaylistEntry(TimestampedModel):

--- a/malcom/houses/tests/test_generate_weekly_playlist_video_command.py
+++ b/malcom/houses/tests/test_generate_weekly_playlist_video_command.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from django.core.management import call_command
 from django.test import TestCase
+from django.utils import timezone
 
 from houses.models import WeeklyPlaylist
 
@@ -112,3 +113,127 @@ class TestGenerateWeeklyPlaylistVideoCommand(TestCase):
             )
 
         mock_insert.assert_not_called()
+
+    @patch("houses.management.commands.generate_weekly_playlist_video.insert_video_at_position")
+    @patch("houses.management.commands.generate_weekly_playlist_video.upload_video_to_youtube")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video")
+    def test_skips_when_upload_and_insert_already_recorded(
+        self, mock_gen: MagicMock, mock_upload: MagicMock, mock_insert: MagicMock
+    ) -> None:
+        """AC: already-uploaded-and-inserted playlist is a no-op."""
+        self.playlist.intro_youtube_video_id = "existing_vid"
+        self.playlist.intro_video_inserted_datetime = timezone.now()
+        self.playlist.save()
+
+        with tempfile.NamedTemporaryFile(suffix=".json") as tmp_secret:
+            call_command(
+                "generate_weekly_playlist_video",
+                str(self.playlist.id),
+                secrets_file=tmp_secret.name,
+            )
+
+        mock_gen.assert_not_called()
+        mock_upload.assert_not_called()
+        mock_insert.assert_not_called()
+
+    @patch("houses.management.commands.generate_weekly_playlist_video.insert_video_at_position")
+    @patch("houses.management.commands.generate_weekly_playlist_video.upload_video_to_youtube")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video")
+    def test_insert_only_when_upload_done_but_insert_missing(
+        self, mock_gen: MagicMock, mock_upload: MagicMock, mock_insert: MagicMock
+    ) -> None:
+        """AC: only insert is retried when upload already persisted."""
+        self.playlist.intro_youtube_video_id = "persisted_vid"
+        self.playlist.save()
+        mock_insert.return_value = True
+
+        with tempfile.NamedTemporaryFile(suffix=".json") as tmp_secret:
+            call_command(
+                "generate_weekly_playlist_video",
+                str(self.playlist.id),
+                secrets_file=tmp_secret.name,
+            )
+
+        mock_gen.assert_not_called()
+        mock_upload.assert_not_called()
+        mock_insert.assert_called_once()
+        insert_args = mock_insert.call_args[0]
+        self.assertEqual(insert_args[0], "PLtest123")
+        self.assertEqual(insert_args[1], "persisted_vid")
+        self.assertEqual(insert_args[2], 0)
+
+        self.playlist.refresh_from_db()
+        self.assertIsNotNone(self.playlist.intro_video_inserted_datetime)
+
+    @patch("houses.management.commands.generate_weekly_playlist_video.insert_video_at_position")
+    @patch("houses.management.commands.generate_weekly_playlist_video.upload_video_to_youtube")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video")
+    def test_force_reuploads_and_clears_prior_state(
+        self, mock_gen: MagicMock, mock_upload: MagicMock, mock_insert: MagicMock
+    ) -> None:
+        """AC: --force bypasses guards and clears prior intro fields before re-render."""
+        self.playlist.intro_youtube_video_id = "old_vid"
+        self.playlist.intro_video_inserted_datetime = timezone.now()
+        self.playlist.save()
+
+        with (
+            tempfile.NamedTemporaryFile(suffix=".mp4") as tmp_video,
+            tempfile.NamedTemporaryFile(suffix=".json") as tmp_secret,
+        ):
+            mock_gen.return_value = Path(tmp_video.name)
+            mock_upload.return_value = "new_vid"
+            mock_insert.return_value = True
+
+            call_command(
+                "generate_weekly_playlist_video",
+                str(self.playlist.id),
+                secrets_file=tmp_secret.name,
+                force=True,
+            )
+
+        mock_gen.assert_called_once()
+        mock_upload.assert_called_once()
+        mock_insert.assert_called_once()
+
+        self.playlist.refresh_from_db()
+        self.assertEqual(self.playlist.intro_youtube_video_id, "new_vid")
+        self.assertIsNotNone(self.playlist.intro_video_inserted_datetime)
+
+    @patch("houses.management.commands.generate_weekly_playlist_video.insert_video_at_position")
+    @patch("houses.management.commands.generate_weekly_playlist_video.upload_video_to_youtube")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video")
+    def test_intro_video_id_persisted_before_insert(
+        self, mock_gen: MagicMock, mock_upload: MagicMock, mock_insert: MagicMock
+    ) -> None:
+        """AC: intro_youtube_video_id is persisted immediately after upload returns.
+
+        Simulate an insert failure (via exception) and assert the id is still
+        saved — proving the save happened before insert was attempted.
+        """
+        captured: dict[str, str | None] = {"id_at_insert_time": None}
+
+        def _check_persisted(*_args: object, **_kwargs: object) -> bool:
+            self.playlist.refresh_from_db()
+            captured["id_at_insert_time"] = self.playlist.intro_youtube_video_id
+            raise RuntimeError("insert boom")
+
+        mock_insert.side_effect = _check_persisted
+
+        with (
+            tempfile.NamedTemporaryFile(suffix=".mp4") as tmp_video,
+            tempfile.NamedTemporaryFile(suffix=".json") as tmp_secret,
+        ):
+            mock_gen.return_value = Path(tmp_video.name)
+            mock_upload.return_value = "persisted_vid"
+
+            with self.assertRaises(RuntimeError):
+                call_command(
+                    "generate_weekly_playlist_video",
+                    str(self.playlist.id),
+                    secrets_file=tmp_secret.name,
+                )
+
+        self.assertEqual(captured["id_at_insert_time"], "persisted_vid")
+        self.playlist.refresh_from_db()
+        self.assertEqual(self.playlist.intro_youtube_video_id, "persisted_vid")
+        self.assertIsNone(self.playlist.intro_video_inserted_datetime)

--- a/malcom/houses/tests/test_post_weekly_playlist.py
+++ b/malcom/houses/tests/test_post_weekly_playlist.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -102,3 +102,62 @@ class TestPostWeeklyPlaylistCommand(TestCase):
         call_command("post_weekly_playlist", "--dry-run", stdout=out)
         output = out.getvalue()
         self.assertIn(str(newer_playlist.id), output)
+
+    def test_skips_when_instagram_post_id_already_set(self) -> None:
+        """AC: already-posted playlist is a no-op."""
+        self.playlist.instagram_post_id = "existing_post_id"
+        self.playlist.save()
+
+        handler_mock = MagicMock(return_value="unused")
+        out = StringIO()
+        with patch(
+            "houses.management.commands.post_weekly_playlist.PLATFORM_HANDLERS",
+            {"instagram": handler_mock},
+        ):
+            call_command("post_weekly_playlist", f"--playlist-id={self.playlist.id}", stdout=out)
+
+        handler_mock.assert_not_called()
+        self.assertIn("already posted", out.getvalue())
+
+    def test_force_reposts_when_instagram_post_id_set(self) -> None:
+        """AC: --force bypasses the guard."""
+        self.playlist.instagram_post_id = "existing_post_id"
+        self.playlist.save()
+
+        handler_mock = MagicMock(return_value="new_post_id")
+        out = StringIO()
+        with (
+            patch(
+                "houses.management.commands.post_weekly_playlist.PLATFORM_HANDLERS",
+                {"instagram": handler_mock},
+            ),
+            patch("houses.management.commands.post_weekly_playlist.settings") as mock_settings,
+        ):
+            mock_settings.INSTAGRAM_USER_ID = "user123"
+            mock_settings.OAUTH_LOCALHOST_CERT = object()
+            mock_settings.OAUTH_LOCALHOST_KEY = object()
+            call_command("post_weekly_playlist", f"--playlist-id={self.playlist.id}", "--force", stdout=out)
+
+        handler_mock.assert_called_once()
+        self.playlist.refresh_from_db()
+        self.assertEqual(self.playlist.instagram_post_id, "new_post_id")
+
+    def test_instagram_post_id_persisted_immediately_after_post(self) -> None:
+        """AC: instagram_post_id is saved immediately after post_carousel returns."""
+        handler_mock = MagicMock(return_value="fresh_post_id")
+        out = StringIO()
+        with (
+            patch(
+                "houses.management.commands.post_weekly_playlist.PLATFORM_HANDLERS",
+                {"instagram": handler_mock},
+            ),
+            patch("houses.management.commands.post_weekly_playlist.settings") as mock_settings,
+        ):
+            mock_settings.INSTAGRAM_USER_ID = "user123"
+            mock_settings.OAUTH_LOCALHOST_CERT = object()
+            mock_settings.OAUTH_LOCALHOST_KEY = object()
+            call_command("post_weekly_playlist", f"--playlist-id={self.playlist.id}", stdout=out)
+
+        handler_mock.assert_called_once()
+        self.playlist.refresh_from_db()
+        self.assertEqual(self.playlist.instagram_post_id, "fresh_post_id")


### PR DESCRIPTION
## Summary

Makes the weekly playlist pipeline idempotent so a re-run after a late-stage failure (e.g. `catbox.moe` HTTP 412 on the Instagram step) does not produce duplicate YouTube intro videos, duplicate YouTube playlists, or duplicate Instagram posts.

Closes monkut/hakoake-backend#42.

## Changes

- `WeeklyPlaylist` gains `intro_youtube_video_id`, `intro_video_inserted_datetime`, `instagram_post_id` (migration `0012`).
- `generate_weekly_playlist_video` short-circuits when both upload+insert are recorded, retries insert-only when upload is recorded but insert is missing, persists state immediately after each API call, and gains a `--force` flag.
- `post_weekly_playlist` skips when `instagram_post_id` is set, persists `post_id` immediately after `post_carousel`, and gains `--force`.
- `create_weekly_playlist` writes the `WeeklyPlaylist` DB record immediately after `create_youtube_playlist()` returns to narrow the orphan window.
- 6 new tests across `test_generate_weekly_playlist_video_command.py` and `test_post_weekly_playlist.py`; full 360-test suite passes; ruff clean.

## Test plan

- [x] New unit tests for: skip-when-already-uploaded-and-inserted, retry-insert-only-when-upload-done-but-insert-missing, `--force` re-upload path, IG skip-when-already-posted, `intro_youtube_video_id` persisted immediately after successful upload, `instagram_post_id` persisted immediately after successful IG post
- [x] Full 360-test suite passes
- [x] ruff clean
- [ ] Manual verification: run `scripts/hakoake-gen-video.sh` twice against a throwaway test week — confirm second run is a no-op
- [ ] Backfill: populate `intro_youtube_video_id` / `intro_video_inserted_datetime` / `instagram_post_id` for the 2026-04-13 `WeeklyPlaylist` before next Monday's cron

## Related

- Context/root cause: `logs/hakoake-gen-video-2026-04-13.log:117` (`catbox.moe` HTTP 412 anon-upload pause) triggered re-runs that duplicated YouTube intro videos.
- Separate follow-up to be filed: catbox fallback / IG image host redundancy.
