### PR TITLE
feat: order resulting playlist by earliest performance date

### DIFF
--- a/malcom/houses/management/commands/create_monthly_playlist.py
+++ b/malcom/houses/management/commands/create_monthly_playlist.py
@@ -23,7 +23,7 @@ from commons.youtube_utils import add_video_to_playlist, create_youtube_playlist
 from django.conf import settings
 from django.core.management import BaseCommand, CommandParser
 from django.db import transaction
-from django.db.models import F
+from django.db.models import F, Min, Q
 from django.utils import timezone
 from houses.formatting import build_lineup_lines, build_playlist_description
 from houses.models import MonthlyPlaylist, MonthlyPlaylistEntry
@@ -102,6 +102,15 @@ class Command(BaseCommand):
                 performance_schedules__performance_date__gte=month_start,
                 performance_schedules__performance_date__lt=month_end,
             )
+            .annotate(
+                earliest_performance_date=Min(
+                    "performance_schedules__performance_date",
+                    filter=Q(
+                        performance_schedules__performance_date__gte=month_start,
+                        performance_schedules__performance_date__lt=month_end,
+                    ),
+                ),
+            )
             .distinct()
             .order_by("-playlist_weight", "name")
         )
@@ -168,6 +177,9 @@ class Command(BaseCommand):
                     f"Only {len(selected_songs)} unique performers/songs found (expected {TOP_PERFORMERS_COUNT})"
                 ),
             )
+
+        # Selection is driven by playlist_weight; output order by performance date.
+        selected_songs.sort(key=lambda ps: ps[0].earliest_performance_date)
 
         lineup_lines = build_lineup_lines(selected_songs, month_start, month_end)
 

--- a/malcom/houses/management/commands/create_weekly_playlist.py
+++ b/malcom/houses/management/commands/create_weekly_playlist.py
@@ -25,7 +25,7 @@ from commons.youtube_utils import add_video_to_playlist, create_youtube_playlist
 from django.conf import settings
 from django.core.management import BaseCommand, CommandParser
 from django.db import transaction
-from django.db.models import F
+from django.db.models import F, Min, Q
 from django.utils import timezone
 from houses.formatting import build_lineup_lines, build_playlist_description
 from houses.models import WeeklyPlaylist, WeeklyPlaylistEntry
@@ -222,6 +222,15 @@ class Command(BaseCommand):
                 performance_schedules__performance_date__gte=week_start,
                 performance_schedules__performance_date__lt=week_end,
             )
+            .annotate(
+                earliest_performance_date=Min(
+                    "performance_schedules__performance_date",
+                    filter=Q(
+                        performance_schedules__performance_date__gte=week_start,
+                        performance_schedules__performance_date__lt=week_end,
+                    ),
+                ),
+            )
             .distinct()
             .order_by("-playlist_weight", "name")
         )
@@ -299,6 +308,9 @@ class Command(BaseCommand):
                 )
             )
             return
+
+        # Selection is driven by playlist_weight; output order by performance date.
+        selected_songs.sort(key=lambda ps: ps[0].earliest_performance_date)
 
         lineup_lines = build_lineup_lines(selected_songs, week_start, week_end)
 


### PR DESCRIPTION
## Summary
- Weekly and monthly playlist commands still *select* performers by `playlist_weight`, but the resulting YouTube playlist position, stored `Entry.position`, and description lineup numbering now follow each performer's earliest performance date in the window (ascending).
- Added `earliest_performance_date` annotation (`Min(performance_schedules__performance_date, filter=Q(<window>))`) to the eligible-performers queryset; sorts `selected_songs` in place before `build_lineup_lines` so all three downstream consumers stay in sync.
- Applies to both `create_weekly_playlist` and `create_monthly_playlist`.

## Test plan
- [x] `uv run ruff check malcom/` — clean
- [x] `cd malcom && uv run python manage.py test houses.tests` — 168 tests pass
- [ ] Dry-run on next week: `uv run python manage.py create_weekly_playlist --dry-run` — confirm lineup is date-ordered
- [ ] Dry-run on next month: `uv run python manage.py create_monthly_playlist 2026-05 --dry-run` — confirm lineup is date-ordered