### PR TITLE
fix: switch IG carousel host from catbox.moe to litterbox.catbox.moe (1h TTL)

### DIFF
--- a/malcom/commons/functions.py
+++ b/malcom/commons/functions.py
@@ -8,43 +8,47 @@ import requests
 YYYY_MM_LENGTH = 7
 YYYY_MM_DD_LENGTH = 10
 
-CATBOX_API_URL = "https://catbox.moe/user/api.php"
+LITTERBOX_API_URL = "https://litterbox.catbox.moe/resources/internals/api.php"
+LITTERBOX_TTL = "1h"
 
 logger = logging.getLogger(__name__)
 
 
-class CatboxUploadError(RuntimeError):
-    """Raised when a catbox.moe upload fails."""
+class LitterboxUploadError(RuntimeError):
+    """Raised when a litterbox.catbox.moe upload fails."""
 
 
-def upload_to_catbox(image_bytes: bytes, filename: str = "image.jpg") -> str:
-    """Upload bytes to catbox.moe anonymously and return the public HTTPS URL.
+def upload_to_litterbox(image_bytes: bytes, filename: str = "image.jpg") -> str:
+    """Upload bytes to litterbox.catbox.moe anonymously and return the public HTTPS URL.
 
-    catbox.moe accepts a multipart POST with `reqtype=fileupload` and returns the
-    URL as plain text in the response body. No API key or signup required.
-    Used wherever a public HTTPS URL is needed for content that is otherwise
-    only available as in-process bytes (e.g. Instagram `image_url` publishing).
+    litterbox.catbox.moe is catbox.moe's temporary-file sibling service. Files expire
+    after ``LITTERBOX_TTL`` (currently ``1h``) — ample for Instagram carousel container
+    creation, which completes in seconds. Accepts a multipart POST with
+    ``reqtype=fileupload`` and ``time=<ttl>`` and returns the URL as plain text.
+    No API key or signup required. Returned URLs are served from ``litter.catbox.moe``.
+    Used wherever a public HTTPS URL is needed briefly for content that is otherwise
+    only available as in-process bytes (e.g. Instagram ``image_url`` publishing).
     """
     try:
         response = requests.post(
-            CATBOX_API_URL,
-            data={"reqtype": "fileupload"},
+            LITTERBOX_API_URL,
+            data={"reqtype": "fileupload", "time": LITTERBOX_TTL},
             files={"fileToUpload": (filename, image_bytes, "image/jpeg")},
             timeout=60,
         )
     except requests.RequestException as exc:
-        raise CatboxUploadError(f"catbox upload failed for {filename!r}: {exc}") from exc
+        raise LitterboxUploadError(f"litterbox upload failed for {filename!r}: {exc}") from exc
 
     if response.status_code != 200:  # noqa: PLR2004
-        raise CatboxUploadError(
-            f"catbox upload failed for {filename!r}: HTTP {response.status_code} — {response.text[:200]}"
+        raise LitterboxUploadError(
+            f"litterbox upload failed for {filename!r}: HTTP {response.status_code} — {response.text[:200]}"
         )
 
     url = response.text.strip()
     if not url.startswith("https://"):
-        raise CatboxUploadError(f"catbox returned unexpected response for {filename!r}: {url[:200]!r}")
+        raise LitterboxUploadError(f"litterbox returned unexpected response for {filename!r}: {url[:200]!r}")
 
-    logger.debug(f"Uploaded {filename!r} to catbox: {url}")
+    logger.debug(f"Uploaded {filename!r} to litterbox: {url}")
     return url
 
 

--- a/malcom/commons/instagram_post.py
+++ b/malcom/commons/instagram_post.py
@@ -5,11 +5,12 @@ static images on the IGwIL API surface — `rupload.facebook.com/ig-api-upload` 
 reels/video only and rejects image uploads with `400 NotAuthorizedError`.
 
 Each carousel slide must therefore be hosted on a publicly fetchable HTTPS URL
-before container creation. We host on catbox.moe (free, no signup, persistent
-URLs, accepts JPEG up to 200 MB).
+before container creation. We host on litterbox.catbox.moe (free, no signup,
+temporary 1h URLs — long enough for Instagram's async fetch, short enough to
+avoid permanent hosting of transient content).
 
 Publish flow:
-  1. Upload each JPEG to catbox.moe → public HTTPS URL
+  1. Upload each JPEG to litterbox.catbox.moe → public HTTPS URL (1h TTL)
   2. Create child container per slide (`is_carousel_item=true`, `image_url=...`)
   3. Poll each child container until `status_code == FINISHED`
   4. Create the parent CAROUSEL container with the children IDs and caption
@@ -27,7 +28,7 @@ import time
 
 import requests
 
-from commons.functions import upload_to_catbox
+from commons.functions import upload_to_litterbox
 
 INSTAGRAM_API_BASE = "https://graph.instagram.com/v22.0"
 
@@ -132,10 +133,10 @@ def post_carousel(
     if not 2 <= len(images) <= 10:  # noqa: PLR2004
         raise ValueError(f"Carousel requires 2-10 images, got {len(images)}")
 
-    # Step 1: upload each image to catbox to obtain a public HTTPS URL
+    # Step 1: upload each image to litterbox to obtain a public HTTPS URL (1h TTL)
     image_urls: list[tuple[str, str]] = []
     for jpeg_bytes, filename in images:
-        public_url = upload_to_catbox(jpeg_bytes, filename)
+        public_url = upload_to_litterbox(jpeg_bytes, filename)
         image_urls.append((public_url, filename))
 
     # Step 2: create one child container per uploaded image

--- a/malcom/commons/tests/test_functions.py
+++ b/malcom/commons/tests/test_functions.py
@@ -5,31 +5,41 @@ from unittest.mock import MagicMock, patch
 import requests
 from django.test import TestCase
 
-from commons.functions import CatboxUploadError, upload_to_catbox
+from commons.functions import LITTERBOX_TTL, LitterboxUploadError, upload_to_litterbox
 
 
-class TestUploadToCatbox(TestCase):
+class TestUploadToLitterbox(TestCase):
     @patch("commons.functions.requests.post")
     def test_returns_https_url_on_success(self, mock_post: MagicMock) -> None:
-        mock_post.return_value = MagicMock(status_code=200, text="https://files.catbox.moe/abc123.jpg\n")
+        mock_post.return_value = MagicMock(status_code=200, text="https://litter.catbox.moe/abc123.jpg\n")
 
-        url = upload_to_catbox(b"\xff\xd8\xff\xe0fake-jpeg", "cover.jpg")
+        url = upload_to_litterbox(b"\xff\xd8\xff\xe0fake-jpeg", "cover.jpg")
 
-        self.assertEqual(url, "https://files.catbox.moe/abc123.jpg")
+        self.assertEqual(url, "https://litter.catbox.moe/abc123.jpg")
         mock_post.assert_called_once()
         _args, kwargs = mock_post.call_args
-        self.assertEqual(kwargs["data"], {"reqtype": "fileupload"})
+        self.assertEqual(kwargs["data"], {"reqtype": "fileupload", "time": LITTERBOX_TTL})
         self.assertIn("fileToUpload", kwargs["files"])
         filename, _bytes, content_type = kwargs["files"]["fileToUpload"]
         self.assertEqual(filename, "cover.jpg")
         self.assertEqual(content_type, "image/jpeg")
 
     @patch("commons.functions.requests.post")
+    def test_sends_time_field_as_1h(self, mock_post: MagicMock) -> None:
+        """Regression: litterbox requires the ``time`` field; omission yields HTTP 400."""
+        mock_post.return_value = MagicMock(status_code=200, text="https://litter.catbox.moe/abc123.jpg")
+
+        upload_to_litterbox(b"jpeg-bytes", "flyer.jpg")
+
+        _args, kwargs = mock_post.call_args
+        self.assertEqual(kwargs["data"].get("time"), "1h")
+
+    @patch("commons.functions.requests.post")
     def test_raises_descriptive_error_on_http_failure(self, mock_post: MagicMock) -> None:
         mock_post.return_value = MagicMock(status_code=500, text="Internal Server Error")
 
-        with self.assertRaises(CatboxUploadError) as cm:
-            upload_to_catbox(b"jpeg-bytes", "flyer_01.jpg")
+        with self.assertRaises(LitterboxUploadError) as cm:
+            upload_to_litterbox(b"jpeg-bytes", "flyer_01.jpg")
 
         self.assertIn("flyer_01.jpg", str(cm.exception))
         self.assertIn("500", str(cm.exception))
@@ -38,8 +48,8 @@ class TestUploadToCatbox(TestCase):
     def test_raises_on_network_error(self, mock_post: MagicMock) -> None:
         mock_post.side_effect = requests.ConnectionError("dns failure")
 
-        with self.assertRaises(CatboxUploadError) as cm:
-            upload_to_catbox(b"jpeg-bytes", "qr_02.jpg")
+        with self.assertRaises(LitterboxUploadError) as cm:
+            upload_to_litterbox(b"jpeg-bytes", "qr_02.jpg")
 
         self.assertIn("qr_02.jpg", str(cm.exception))
         self.assertIn("dns failure", str(cm.exception))
@@ -48,7 +58,7 @@ class TestUploadToCatbox(TestCase):
     def test_raises_when_response_is_not_https_url(self, mock_post: MagicMock) -> None:
         mock_post.return_value = MagicMock(status_code=200, text="something went wrong")
 
-        with self.assertRaises(CatboxUploadError) as cm:
-            upload_to_catbox(b"jpeg-bytes", "x.jpg")
+        with self.assertRaises(LitterboxUploadError) as cm:
+            upload_to_litterbox(b"jpeg-bytes", "x.jpg")
 
         self.assertIn("x.jpg", str(cm.exception))

--- a/malcom/commons/tests/test_instagram_post.py
+++ b/malcom/commons/tests/test_instagram_post.py
@@ -64,7 +64,7 @@ class TestPostCarousel(TestCase):
     @patch("commons.instagram_post.wait_for_container_finished", return_value=None)
     @patch("commons.instagram_post.create_carousel_container", return_value="parent-99")
     @patch("commons.instagram_post.create_carousel_item")
-    @patch("commons.instagram_post.upload_to_catbox")
+    @patch("commons.instagram_post.upload_to_litterbox")
     def test_end_to_end_happy_path(
         self,
         mock_upload: MagicMock,
@@ -74,9 +74,9 @@ class TestPostCarousel(TestCase):
         mock_publish: MagicMock,
     ) -> None:
         mock_upload.side_effect = [
-            "https://files.catbox.moe/cover.jpg",
-            "https://files.catbox.moe/slide1.jpg",
-            "https://files.catbox.moe/slide2.jpg",
+            "https://litter.catbox.moe/cover.jpg",
+            "https://litter.catbox.moe/slide1.jpg",
+            "https://litter.catbox.moe/slide2.jpg",
         ]
         mock_create_item.side_effect = ["c1", "c2", "c3"]
 

--- a/malcom/houses/tests/test_instagram_post.py
+++ b/malcom/houses/tests/test_instagram_post.py
@@ -81,8 +81,8 @@ class TestPostCarousel(TestCase):
     @patch("commons.instagram_post.create_carousel_container", return_value="container_99")
     @patch("commons.instagram_post.create_carousel_item", side_effect=["child_1", "child_2"])
     @patch(
-        "commons.instagram_post.upload_to_catbox",
-        side_effect=["https://files.catbox.moe/a.jpg", "https://files.catbox.moe/b.jpg"],
+        "commons.instagram_post.upload_to_litterbox",
+        side_effect=["https://litter.catbox.moe/a.jpg", "https://litter.catbox.moe/b.jpg"],
     )
     def test_full_flow_returns_post_id(
         self,


### PR DESCRIPTION
## Summary

- Switch the Instagram carousel upload path from `catbox.moe` (permanent) to `litterbox.catbox.moe` (temporary, 1h TTL) — Instagram only needs the URL alive for seconds during container creation, so permanent hosting is the wrong default.
- Rename `upload_to_catbox` → `upload_to_litterbox`, `CatboxUploadError` → `LitterboxUploadError`, add the required `time=1h` form field. Response domain is `litter.catbox.moe`.
- Port test fixtures across `commons` and `houses` test modules. Add regression test asserting `time=1h` is sent (litterbox returns HTTP 400 without it).

## Evidence

Live check from the production host immediately before this change:

| Endpoint | Result |
|---|---|
| `POST https://litterbox.catbox.moe/resources/internals/api.php` (`time=1h`) | HTTP 200 → `https://litter.catbox.moe/z2s80m.txt` |
| `POST https://catbox.moe/user/api.php` | timeout after 30s |

catbox.moe is currently unavailable; litterbox is operational. This change unblocks the IG pipeline immediately.

## Test plan

- [x] `commons.tests.test_functions` — 6 tests (5 ported + 1 new regression for `time=1h`)
- [x] `commons.tests.test_instagram_post` — carousel happy-path patched to `upload_to_litterbox`, fixture URLs updated
- [x] `houses.tests.test_instagram_post` — patch target + fixture URLs updated
- [x] Full suite: 23/23 pass (`uv run python manage.py test commons.tests.test_functions commons.tests.test_instagram_post houses.tests.test_instagram_post`)
- [x] Ruff + pyright clean on changed files (pre-existing PLC0415 on `houses/tests/test_instagram_post.py:70` left alone — out of scope)
- [x] Grep audit: zero `upload_to_catbox` / `CatboxUploadError` / `catbox.moe/user` references remain under `malcom/`
- [ ] Post-merge manual verification: run `python manage.py post_weekly_playlist --platform instagram` against a real Instagram account

## Related

- Closes #50
- Re-scopes #48 — fallback host work is still needed; see updated scope comment on #48. Default chain now starts with litterbox and must include at least one independently operated host (e.g. `0x0.st`) because litterbox shares infrastructure with catbox.
- Follow-up in ellen-core: retire the `hakoake-catbox-watchdog` cron job once this ships (weyucou/ellen-core#77).