### PR TITLE
fix(scripts): target next week's Monday in hakoake-gen-video (#59)

### DIFF
--- a/scripts/hakoake-gen-video.sh
+++ b/scripts/hakoake-gen-video.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # hakoake-gen-video.sh — Generate weekly playlist video for hakoake.
-# Runs every Monday at 22:00 JST.
-# 1. Creates the weekly playlist for the current Monday
+# Runs every Monday at 22:00 JST, targeting next Monday's week.
+# 1. Creates the weekly playlist for next Monday
 # 2. Looks up the created playlist's DB id
 # 3. Generates the playlist video
 # 4. Posts the Instagram carousel announcement
@@ -13,8 +13,8 @@ HAKOAKE_DIR="$HOME/projects/hakoake-backend/malcom"
 LOG_DIR="$HOME/projects/hakoake-backend/logs"
 mkdir -p "$LOG_DIR"
 
-# Get Monday date in JST (the day this script runs)
-MONDAY=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+# Get next Monday's date in JST (today + 7 days) — target the upcoming week
+MONDAY=$(TZ=Asia/Tokyo date -d '+7 days' +%Y-%m-%d)
 LOGFILE="$LOG_DIR/hakoake-gen-video-${MONDAY}.log"
 
 # Tee all output (stdout + stderr) to a dated log file


### PR DESCRIPTION
## Summary

- Shift `MONDAY` in `scripts/hakoake-gen-video.sh` from today to `today + 7 days` so the weekly playlist pipeline targets the upcoming week, not the week that just finished.
- Update the script's header and inline comments to reflect the new semantics.

Closes #59

## Why

The cron job runs every Monday at 22:00 JST. Previously `MONDAY=$(TZ=Asia/Tokyo date +%Y-%m-%d)` resolved to **today**, so `create_weekly_playlist`, `generate_weekly_playlist_video`, and `post_weekly_playlist` all produced artifacts for the week that had already started / was ending. The announcement slides landed after the fact.

With `date -d '+7 days'`, the same `$MONDAY` value is passed to all four `manage.py` subcommands (and into the log filename), so the announcement goes out one week ahead, as intended.

## Test plan

- [x] `TZ=Asia/Tokyo date -d '+7 days' +%Y-%m-%d` returns the Monday that is 7 days after the current Monday (verified: 2026-04-21 → 2026-04-28).
- [x] `bash -n scripts/hakoake-gen-video.sh` — syntax OK.
- [ ] Next Monday run: confirm `logs/hakoake-gen-video-<next-monday>.log` is created and the playlist/video/IG post all reference the correct upcoming week.