### PR TITLE
chore: add nightly hakoake-fetch-performer-images.sh (#58)

### DIFF
--- a/scripts/hakoake-fetch-performer-images.sh
+++ b/scripts/hakoake-fetch-performer-images.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# hakoake-fetch-performer-images.sh — Backfill missing performer images nightly.
+# Runs fetch_performer_images --missing-only so new performers have artwork
+# before the Monday post_weekly_playlist run (hakoake-gen-video.sh, 22:00 JST).
+set -euo pipefail
+
+export PATH="/home/monkut/.local/bin:$PATH"
+
+HAKOAKE_DIR="$HOME/projects/hakoake-backend/malcom"
+LOG_DIR="$HOME/projects/hakoake-backend/logs"
+mkdir -p "$LOG_DIR"
+
+TODAY=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+LOGFILE="$LOG_DIR/hakoake-fetch-performer-images-${TODAY}.log"
+
+# Tee all output (stdout + stderr) to a dated log file
+exec > >(tee "$LOGFILE") 2>&1
+
+cd "$HAKOAKE_DIR"
+
+echo "Fetching missing performer images..."
+uv run python manage.py fetch_performer_images --missing-only
+
+echo "Done."


### PR DESCRIPTION
## Summary

Adds `scripts/hakoake-fetch-performer-images.sh` — a nightly wrapper around `fetch_performer_images --missing-only` so new performers have artwork before the Monday `post_weekly_playlist` run in `hakoake-gen-video.sh`.

Structure mirrors `hakoake-collect-and-validate.sh` (PATH export, dated log under `logs/`, `TZ=Asia/Tokyo`). No day-gate — intended to run nightly.

## Scope

This PR only adds the script. The remaining tasks on #58 are owner-managed and cannot be done from the repo:

- One-shot backfill run of `fetch_performer_images --missing-only`
- Host-side timer/cron install (suggested 03:00 JST nightly, must fire before Monday 22:00 JST `hakoake-gen-video.sh`)
- Dry-run `post_weekly_playlist` the Monday after the timer is installed — gated on #57 also being merged, otherwise the solid-black fallback masks success

## Test plan

- [ ] Script is executable (`chmod +x` applied)
- [ ] `bash -n scripts/hakoake-fetch-performer-images.sh` — syntax check
- [ ] Manual smoke: `./scripts/hakoake-fetch-performer-images.sh` produces a dated log file under `logs/`
- [ ] Timer installed on host and first overnight run logs a successful `fetch_performer_images --missing-only` invocation

Refs #58. Related: #55, #57.