### PR TITLE
fix(instagram): restore insta-background.png fallback in generate_performer_card() (#57)

### DIFF
--- a/malcom/commons/instagram_images.py
+++ b/malcom/commons/instagram_images.py
@@ -56,6 +56,13 @@ logger = logging.getLogger(__name__)
 # Kept as module-level constants for back-compat with tests and external callers.
 IMG_W, IMG_H = INSTAGRAM_SQUARE
 
+# Fallback background image used when no performer photo or event flyer is
+# available. Lives at the repo root (two levels above this module). Restored
+# from commit b8aced6; the intervening design-system refactor (7b7dbd5)
+# dropped this step, causing the fallback chain to skip straight to solid
+# PAPER_BLACK.
+_INSTA_BG = Path(__file__).resolve().parent.parent.parent / "insta-background.png"
+
 INSTAGRAM_HASHTAGS = (
     "hakoake",
     "tokyo",
@@ -109,6 +116,39 @@ def _paper_black_canvas() -> Image.Image:
     """Return a fresh PAPER_BLACK canvas with paper grain applied."""
     base = Image.new("RGB", INSTAGRAM_SQUARE, PAPER_BLACK)
     return apply_paper_grain(base)
+
+
+def _load_insta_fallback_bg(size: tuple[int, int]) -> Image.Image | None:
+    """Load `insta-background.png` scaled/cropped to `size`, composited at 60% opacity over PAPER_BLACK.
+
+    Mirrors the treatment originally introduced in commit b8aced6. Returns
+    None if the file is missing or cannot be loaded — callers should fall
+    through to the next background option.
+    """
+    if not _INSTA_BG.exists():
+        return None
+    try:
+        bg = Image.open(_INSTA_BG).convert("RGBA")
+    except (OSError, ValueError) as exc:
+        logger.debug(f"Could not load fallback background {_INSTA_BG}: {exc}")
+        return None
+
+    target_w, target_h = size
+    ratio = max(target_w / bg.width, target_h / bg.height)
+    new_w = int(bg.width * ratio)
+    new_h = int(bg.height * ratio)
+    bg = bg.resize((new_w, new_h), Image.Resampling.LANCZOS)
+    x = (new_w - target_w) // 2
+    y = (new_h - target_h) // 2
+    bg = bg.crop((x, y, x + target_w, y + target_h))
+
+    r, g, b, a = bg.split()
+    a = a.point(lambda v: int(v * 0.6))
+    bg = Image.merge("RGBA", (r, g, b, a))
+
+    base = Image.new("RGBA", size, (*PAPER_BLACK, 255))
+    base.alpha_composite(bg)
+    return base.convert("RGB")
 
 
 def _resize_to_square(raw_bytes: bytes, size: int = 1080) -> bytes:
@@ -233,12 +273,17 @@ def generate_performer_card(
     photo_h = int(IMG_H * 0.62)
 
     # --- Photo region ---
+    # Fallback chain: performer image → insta-background.png → brand background → PAPER_BLACK.
     photo_canvas = Image.new("RGB", INSTAGRAM_SQUARE, PAPER_BLACK)
     if source_img is not None:
         photo = scale_to_fill(source_img, (IMG_W, photo_h))
     else:
-        bg = load_brand_background((IMG_W, photo_h))
-        photo = bg if bg is not None else Image.new("RGB", (IMG_W, photo_h), PAPER_BLACK)
+        insta_fallback = _load_insta_fallback_bg((IMG_W, photo_h))
+        if insta_fallback is not None:
+            photo = insta_fallback
+        else:
+            bg = load_brand_background((IMG_W, photo_h))
+            photo = bg if bg is not None else Image.new("RGB", (IMG_W, photo_h), PAPER_BLACK)
     photo_canvas.paste(photo, (0, 0))
 
     # --- Paper black caption panel under the photo ---

--- a/malcom/commons/tests/test_instagram_images.py
+++ b/malcom/commons/tests/test_instagram_images.py
@@ -7,11 +7,19 @@ tests assert that Japanese glyphs render with real (non-notdef) widths.
 
 import io
 from datetime import date
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from PIL import Image, ImageDraw, ImageFont
 
-from commons.instagram_images import IMG_H, IMG_W, _font, generate_combined_flyer_qr_slide
+from commons.design import PAPER_BLACK
+from commons.instagram_images import (
+    IMG_H,
+    IMG_W,
+    _font,
+    generate_combined_flyer_qr_slide,
+    generate_performer_card,
+)
 
 JAPANESE_SAMPLE = "残響のリフレイン"
 LATIN_SAMPLE = "HAKKO-AKKEI"
@@ -118,3 +126,53 @@ class TestCombinedFlyerQrSlide(TestCase):
         )
         img = Image.open(io.BytesIO(result))
         self.assertEqual(img.size, (IMG_W, IMG_H))
+
+
+def _is_near_paper_black(pixel: tuple[int, int, int], tolerance: int = 15) -> bool:
+    """True if the pixel's per-channel sum-of-diffs vs PAPER_BLACK is within tolerance."""
+    return sum(abs(pixel[i] - PAPER_BLACK[i]) for i in range(3)) <= tolerance
+
+
+class TestPerformerCardFallback(TestCase):
+    """Regression guard for #57: insta-background.png must be used when no performer/event image exists.
+
+    Commit 7b7dbd5 (design-system refactor) dropped the insta-background.png
+    step originally introduced in b8aced6, so the fallback chain jumped
+    straight to solid PAPER_BLACK.
+    """
+
+    def _make_performer_with_no_images(self) -> MagicMock:
+        performer = MagicMock()
+        performer.name = "TestBand"
+        performer.name_romaji = ""
+        for field in ("performer_image", "fanart_image", "banner_image", "logo_image"):
+            empty_field = MagicMock()
+            empty_field.name = ""
+            setattr(performer, field, empty_field)
+        return performer
+
+    def test_uses_insta_background_when_performer_and_brand_bg_unavailable(self) -> None:
+        """With no performer images AND brand background patched to None, the photo
+        region must still have colour — proving insta-background.png was applied.
+        """
+        performer = self._make_performer_with_no_images()
+
+        with patch("commons.instagram_images.load_brand_background", return_value=None):
+            result = generate_performer_card(performer, position=1, schedules=[])
+
+        img = Image.open(io.BytesIO(result)).convert("RGB")
+        self.assertEqual(img.size, (IMG_W, IMG_H))
+
+        # Sample pixels from the top third of the photo region (62% of IMG_H).
+        # Paper grain adds ~1-2 units of jitter, so we tolerate 15 units of
+        # per-channel total drift when classifying a pixel as "near PAPER_BLACK".
+        photo_h = int(IMG_H * 0.62)
+        sample_y = photo_h // 4
+        pixels = [img.getpixel((x, sample_y)) for x in range(20, IMG_W, IMG_W // 16)]
+        non_black = [px for px in pixels if not _is_near_paper_black(px)]
+        self.assertGreater(
+            len(non_black),
+            len(pixels) // 2,
+            f"Performer card photo region fell through to solid PAPER_BLACK at row {sample_y}; "
+            f"insta-background.png fallback not applied. Sampled pixels: {pixels}",
+        )


### PR DESCRIPTION
## Summary

Commit `b8aced6` introduced `insta-background.png` as the fallback background for Instagram performer cards when no performer or flyer image was available. The design-system refactor in `7b7dbd5` dropped that step, so the fallback chain now jumps straight to solid PAPER_BLACK — producing black cards in the weekly post when performer images are missing.

Restores the step between performer-image and brand-background in `generate_performer_card()`'s photo-region fallback chain, using the same 60%-opacity composite over PAPER_BLACK as the original.

**Restored chain:** performer image → `insta-background.png` → `load_brand_background()` → solid PAPER_BLACK.

## Changes

- `malcom/commons/instagram_images.py`
  - New `_INSTA_BG` module constant pointing at `<repo>/insta-background.png`
  - New `_load_insta_fallback_bg(size)` helper — loads, scales, crops, applies 60% opacity, composites over PAPER_BLACK
  - `generate_performer_card()` now tries the fallback between `_load_performer_image()` and `load_brand_background()`
- `malcom/commons/tests/test_instagram_images.py`
  - New `TestPerformerCardFallback` — patches `load_brand_background` to `None` and asserts the photo region is non-PAPER_BLACK. Any future refactor that drops this step will fail the suite rather than produce black posts in production.

## Test plan

- [x] `uv run python manage.py test commons.tests.test_instagram_images` — 7/7 pass (including new test)
- [x] `uv run python manage.py test commons houses.tests.test_post_weekly_playlist houses.tests.test_instagram_images houses.tests.test_instagram_post houses.tests.test_video_slide_renderers` — 95/95 pass
- [x] `uv run ruff check malcom/commons/instagram_images.py malcom/commons/tests/test_instagram_images.py` — clean
- [ ] Post-merge: dry-run `post_weekly_playlist` for the upcoming week and confirm cards use `insta-background.png` rather than solid black when performer images are unavailable (tracked on #58)

Closes #57. Related: #55, #58.