### PR TITLE
chore: gitignore Instagram/Threads OAuth token JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,4 +243,5 @@ malcom/staticfiles/*
 
 # Backups and session files
 *.bak
+.claude/worktrees/
 CHECKPOINT.md

--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,7 @@ malcom/staticfiles/*
 *.bak
 .claude/worktrees/
 CHECKPOINT.md
+
+# Instagram/Threads OAuth token files (contain live access tokens)
+instagram_token.json
+threads_token.json


### PR DESCRIPTION
## Summary
- Adds `instagram_token.json` and `threads_token.json` to `.gitignore` to prevent accidental commit of live OAuth access tokens.

## Why
Both files contain real bearer tokens with future expiry dates. They were previously untracked and at risk of being committed alongside the existing `.gitignore` patterns chore on this branch.