### PR TITLE
fix: use gemma4:e4b as default Ollama model for playlist intro text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,4 +243,5 @@ malcom/staticfiles/*
 
 # Backups and session files
 *.bak
+.claude/worktrees/
 CHECKPOINT.md

--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,7 @@ malcom/staticfiles/*
 *.bak
 .claude/worktrees/
 CHECKPOINT.md
+
+# Instagram/Threads OAuth token files (contain live access tokens)
+instagram_token.json
+threads_token.json

--- a/malcom/malcom/settings.py
+++ b/malcom/malcom/settings.py
@@ -285,7 +285,7 @@ THREADS_USER_ID = os.getenv("THREADS_USER_ID", "")  # populated after first OAut
 OAUTH_LOCALHOST_CERT = BASE_DIR.parent / "localhost.pem"
 OAUTH_LOCALHOST_KEY = BASE_DIR.parent / "localhost-key.pem"
 
-PLAYLIST_INTRO_TEXT_GENERATION_MODEL = "mistral-small"
+PLAYLIST_INTRO_TEXT_GENERATION_MODEL = os.getenv("PLAYLIST_INTRO_TEXT_GENERATION_MODEL", "gemma4:e4b")
 
 # TTS Configuration for video generation
 VIDEO_TTS_MODEL = "legraphista/Orpheus:3b-ft-q4_k_m"  # noqa: N806


### PR DESCRIPTION
## Summary

- `mistral-small` Ollama model is no longer installed on the host; the `hakoake-gen-video` cron has been failing since 2026-04-27
- Updates `PLAYLIST_INTRO_TEXT_GENERATION_MODEL` default from `mistral-small` → `gemma4:e4b` (8B, Q4_K_M — currently installed)
- Makes the setting env-configurable via `os.getenv()` so future model swaps don't require code changes

Fixes #64

## Test plan

- [ ] Merge and verify `hakoake-gen-video` cron succeeds on next scheduled run (2026-05-04 22:00 JST)
- [ ] Confirm intro text is generated without Ollama errors in the log