### PR TITLE
feat(crawlers): add ShibuyaONestCrawler for Shibuya O-Nest

### DIFF
--- a/malcom/houses/crawlers/__init__.py
+++ b/malcom/houses/crawlers/__init__.py
@@ -10,6 +10,7 @@ from .rockmaykan import RockmaykanCrawler
 from .club_que import ClubQueCrawler
 from .garret import GarretCrawler
 from .fever_popo import FeverPopoCrawler
+from .shibuya_o_nest import ShibuyaONestCrawler
 
 __all__ = [
     "LiveHouseWebsiteCrawler",
@@ -25,4 +26,5 @@ __all__ = [
     "ClubQueCrawler",
     "GarretCrawler",
     "FeverPopoCrawler",
+    "ShibuyaONestCrawler",
 ]

--- a/malcom/houses/crawlers/shibuya_o_nest.py
+++ b/malcom/houses/crawlers/shibuya_o_nest.py
@@ -1,0 +1,181 @@
+import logging
+import re
+
+from django.utils import timezone
+
+from ..models import LiveHouse
+from .crawler import CrawlerRegistry, LiveHouseWebsiteCrawler
+
+logger = logging.getLogger(__name__)
+
+SHIBUYA_O_NEST_BASE_URL = "https://shibuya-o.com/nest"
+SHIBUYA_O_NEST_API_URL = "https://shibuya-o.com/wp-json/wp/v2/nest-schedule"
+
+
+@CrawlerRegistry.register("ShibuyaONestCrawler")
+class ShibuyaONestCrawler(LiveHouseWebsiteCrawler):
+    """
+    Crawler for Shibuya O-Nest (shibuya-o.com/nest/).
+
+    The schedule list page is JavaScript-rendered. Events are fetched via the
+    WordPress REST API (nest-schedule custom post type). Each event's detail
+    page is server-rendered HTML and parsed for date, time, and performers.
+
+    Detail page structure:
+    - Date:       .p-schedule-detail__date-item  e.g. "05 / 14"
+    - Day of week:.p-schedule-detail__date-week  e.g. "THU"
+    - OPEN/START: .p-schedule-detail__dt / .p-schedule-detail__dd
+    - Performers: .c-wp-editor <p> with "出演：A / B / C"
+    - Image:      img.wp-post-image
+    """
+
+    def extract_live_house_info(self, html_content: str) -> dict[str, str]:
+        return {
+            "name": "Shibuya O-Nest",
+            "name_kana": "シブヤ オーネスト",
+            "name_romaji": "Shibuya O-Nest",
+            "address": "",
+            "phone_number": "",
+            "capacity": 0,
+            "opened_date": None,
+        }
+
+    def find_schedule_link(self, html_content: str) -> str | None:
+        return SHIBUYA_O_NEST_API_URL
+
+    def process_performance_schedules(self, schedule_url: str, live_house: LiveHouse) -> None:
+        schedules = self._fetch_all_schedules_via_api()
+        created_count = 0
+        total_performers: set[str] = set()
+
+        for schedule_data in schedules:
+            try:
+                performance = self.create_performance_schedule(live_house, schedule_data)
+                created_count += 1
+                for performer in performance.performers.all():
+                    total_performers.add(performer.name)
+            except Exception:  # noqa: BLE001
+                logger.exception(f"Failed to create schedule for {schedule_data}")
+
+        logger.info(f"Created {created_count} performance schedules for {live_house.name}")
+        if total_performers:
+            logger.info(f"  Unique performers: {len(total_performers)}")
+
+    def extract_performance_schedules(self, html_content: str) -> list[dict]:
+        # Not called — process_performance_schedules is overridden to use the REST API.
+        return []
+
+    def _fetch_all_schedules_via_api(self) -> list[dict]:
+        schedules = []
+        page = 1
+        while True:
+            url = f"{SHIBUYA_O_NEST_API_URL}?per_page=100&page={page}"
+            response = self.session.get(url, timeout=self.timeout)
+            if response.status_code in (400, 404):
+                break
+            response.raise_for_status()
+            posts = response.json()
+            if not posts:
+                break
+            for post in posts:
+                schedule = self._parse_detail_page(post["link"])
+                if schedule:
+                    schedules.append(schedule)
+            total_pages = int(response.headers.get("X-WP-TotalPages", 1))
+            if page >= total_pages:
+                break
+            page += 1
+        logger.info(f"Fetched {len(schedules)} schedules from O-Nest REST API")
+        return schedules
+
+    def _parse_detail_page(self, url: str) -> dict | None:
+        try:
+            html = self.fetch_page(url)
+            return self._parse_detail_html(html, url)
+        except Exception:  # noqa: BLE001
+            logger.warning(f"Failed to fetch/parse O-Nest detail page: {url}")
+            return None
+
+    def _parse_detail_html(self, html: str, source_url: str) -> dict | None:
+        soup = self.create_soup(html)
+        date_str = self._extract_date_str(soup, source_url)
+        if not date_str:
+            return None
+
+        open_time, start_time = self._extract_open_start_from_dl(soup)
+        event_name = self._extract_event_name(soup)
+        performers = self._extract_performers_from_content(soup, event_name)
+        event_image_url = self._extract_event_image_url(soup)
+        content_div = soup.find("div", class_="c-wp-editor")
+        context_parts = [event_name]
+        if content_div:
+            context_parts.append(content_div.get_text(separator=" ", strip=True))
+
+        schedule: dict = {
+            "date": date_str,
+            "open_time": open_time or "18:30",
+            "start_time": start_time or "19:00",
+            "performers": performers,
+            "performance_name": event_name,
+            "source_url": source_url,
+            "context": "\n".join(context_parts),
+        }
+        if event_image_url:
+            schedule["event_image_url"] = event_image_url
+        return schedule
+
+    def _extract_date_str(self, soup: object, source_url: str) -> str | None:
+        date_item = soup.find("span", class_="p-schedule-detail__date-item")  # type: ignore[union-attr]
+        if not date_item:
+            logger.debug(f"No date element found on: {source_url}")
+            return None
+        date_text = date_item.get_text(strip=True)
+        date_match = re.match(r"(\d{1,2})\s*/\s*(\d{1,2})", date_text)
+        if not date_match:
+            logger.debug(f"Unparsable date '{date_text}' on: {source_url}")
+            return None
+        month = int(date_match.group(1))
+        day = int(date_match.group(2))
+        today = timezone.localdate()
+        year = today.year
+        if today.month >= 11 and month <= 2:  # noqa: PLR2004
+            year += 1
+        return f"{year:04d}-{month:02d}-{day:02d}"
+
+    def _extract_open_start_from_dl(self, soup: object) -> tuple[str | None, str | None]:
+        open_time: str | None = None
+        start_time: str | None = None
+        for dl in soup.find_all("div", class_="p-schedule-detail__dl"):  # type: ignore[union-attr]
+            dt_el = dl.find("div", class_="p-schedule-detail__dt")
+            dd_el = dl.find("div", class_="p-schedule-detail__dd")
+            if not (dt_el and dd_el):
+                continue
+            dt_text = dt_el.get_text(strip=True)
+            dd_text = dd_el.get_text(strip=True)
+            if dt_text == "OPEN":
+                open_time = dd_text
+            elif dt_text == "START":
+                start_time = dd_text
+        return open_time, start_time
+
+    def _extract_event_name(self, soup: object) -> str:
+        title_span = soup.find("span", class_="p-schedule-detail__title-main")  # type: ignore[union-attr]
+        return title_span.get_text(strip=True) if title_span else ""
+
+    def _extract_performers_from_content(self, soup: object, event_name: str) -> list[str]:
+        content_div = soup.find("div", class_="c-wp-editor")  # type: ignore[union-attr]
+        performers: list[str] = []
+        if content_div:
+            content_text = content_div.get_text(separator=" ", strip=True)
+            content_text = re.sub(r"^出演[：:]\s*", "", content_text)
+            for raw_name in re.split(r"\s*/\s*|／", content_text):
+                cleaned = self._clean_performer_name(raw_name.strip())
+                if cleaned and self._is_valid_performer_name(cleaned):
+                    performers.append(cleaned)
+        if not performers and event_name:
+            performers = [event_name]
+        return performers
+
+    def _extract_event_image_url(self, soup: object) -> str | None:
+        img = soup.find("img", class_="wp-post-image")  # type: ignore[union-attr]
+        return img["src"] if img and img.get("src") else None

--- a/malcom/houses/tests/test_crawlers_shibuya_o_nest.py
+++ b/malcom/houses/tests/test_crawlers_shibuya_o_nest.py
@@ -1,0 +1,193 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from houses.crawlers import ShibuyaONestCrawler
+from houses.definitions import WebsiteProcessingState
+from houses.models import LiveHouseWebsite
+
+DETAIL_HTML_FULL = """\
+<html lang="ja">
+<body>
+<div id="content" class="l-content p-schedule-detail">
+  <div class="p-schedule-detail__row">
+    <div class="p-schedule-detail__image">
+      <div class="p-schedule-detail__image-item">
+        <img src="https://example.com/flyer.jpg"
+             class="attachment-large size-large wp-post-image" alt="">
+      </div>
+    </div>
+    <div class="p-schedule-detail__main">
+      <div class="p-schedule-detail__blcok">
+        <div class="p-schedule-detail__date">
+          <span class="p-schedule-detail__date-item">05 / 14</span>
+          <span class="p-schedule-detail__date-week is-THU">THU</span>
+        </div>
+        <h3 class="p-schedule-detail__title">
+          <span class="p-schedule-detail__title-main">『あいらんど chapter3』</span>
+        </h3>
+      </div>
+      <div class="p-schedule-detail__blcok">
+        <div class="c-wp-editor">
+          <p>出演：Aivery / しろもん / Falench.</p>
+        </div>
+      </div>
+      <div class="p-schedule-detail__blcok">
+        <div class="p-schedule-detail__dl">
+          <div class="p-schedule-detail__dt">OPEN</div>
+          <div class="p-schedule-detail__dd">17:00</div>
+        </div>
+        <div class="p-schedule-detail__dl">
+          <div class="p-schedule-detail__dt">START</div>
+          <div class="p-schedule-detail__dd">17:15</div>
+        </div>
+        <div class="p-schedule-detail__dl">
+          <div class="p-schedule-detail__dt">前方</div>
+          <div class="p-schedule-detail__dd">¥3,000</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>
+"""
+
+DETAIL_HTML_NO_PERFORMERS = """\
+<html lang="ja">
+<body>
+<div class="p-schedule-detail__date">
+  <span class="p-schedule-detail__date-item">06 / 01</span>
+  <span class="p-schedule-detail__date-week is-MON">MON</span>
+</div>
+<h3 class="p-schedule-detail__title">
+  <span class="p-schedule-detail__title-main">Solo Event</span>
+</h3>
+<div class="p-schedule-detail__dl">
+  <div class="p-schedule-detail__dt">OPEN</div>
+  <div class="p-schedule-detail__dd">18:30</div>
+</div>
+<div class="p-schedule-detail__dl">
+  <div class="p-schedule-detail__dt">START</div>
+  <div class="p-schedule-detail__dd">19:00</div>
+</div>
+</body>
+</html>
+"""
+
+DETAIL_HTML_NO_DATE = """\
+<html lang="ja">
+<body>
+<h3 class="p-schedule-detail__title">
+  <span class="p-schedule-detail__title-main">Event Without Date</span>
+</h3>
+</body>
+</html>
+"""
+
+
+class TestShibuyaONestCrawler(TestCase):
+    def setUp(self):
+        self.website = LiveHouseWebsite.objects.create(
+            url="https://shibuya-o.com/nest/",
+            state=WebsiteProcessingState.NOT_STARTED,
+            crawler_class="ShibuyaONestCrawler",
+        )
+        self.crawler = ShibuyaONestCrawler(self.website)
+
+    def test_extract_live_house_info(self):
+        info = self.crawler.extract_live_house_info("")
+        self.assertEqual(info["name"], "Shibuya O-Nest")
+        self.assertEqual(info["name_kana"], "シブヤ オーネスト")
+        self.assertEqual(info["name_romaji"], "Shibuya O-Nest")
+
+    def test_find_schedule_link_returns_api_url(self):
+        url = self.crawler.find_schedule_link("")
+        self.assertEqual(url, "https://shibuya-o.com/wp-json/wp/v2/nest-schedule")
+
+    def test_parse_detail_html_date_and_times(self):
+        with patch.object(timezone, "localdate", return_value=timezone.datetime(2026, 5, 1).date()):
+            result = self.crawler._parse_detail_html(DETAIL_HTML_FULL, "https://shibuya-o.com/nest/schedule/test/")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["date"], "2026-05-14")
+        self.assertEqual(result["open_time"], "17:00")
+        self.assertEqual(result["start_time"], "17:15")
+
+    def test_parse_detail_html_performers(self):
+        with patch.object(timezone, "localdate", return_value=timezone.datetime(2026, 5, 1).date()):
+            result = self.crawler._parse_detail_html(DETAIL_HTML_FULL, "https://shibuya-o.com/nest/schedule/test/")
+        self.assertIsNotNone(result)
+        self.assertIn("Aivery", result["performers"])
+        self.assertIn("しろもん", result["performers"])
+        self.assertIn("Falench.", result["performers"])
+
+    def test_parse_detail_html_event_image(self):
+        with patch.object(timezone, "localdate", return_value=timezone.datetime(2026, 5, 1).date()):
+            result = self.crawler._parse_detail_html(DETAIL_HTML_FULL, "https://shibuya-o.com/nest/schedule/test/")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get("event_image_url"), "https://example.com/flyer.jpg")
+
+    def test_parse_detail_html_no_performers_falls_back_to_event_name(self):
+        with patch.object(timezone, "localdate", return_value=timezone.datetime(2026, 6, 1).date()):
+            result = self.crawler._parse_detail_html(
+                DETAIL_HTML_NO_PERFORMERS, "https://shibuya-o.com/nest/schedule/test/"
+            )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["performers"], ["Solo Event"])
+
+    def test_parse_detail_html_missing_date_returns_none(self):
+        result = self.crawler._parse_detail_html(DETAIL_HTML_NO_DATE, "https://shibuya-o.com/nest/schedule/test/")
+        self.assertIsNone(result)
+
+    def test_parse_detail_html_year_rollover(self):
+        # When crawling in December, January events belong to next year
+        with patch.object(timezone, "localdate", return_value=timezone.datetime(2026, 12, 15).date()):
+            html = DETAIL_HTML_NO_PERFORMERS.replace("06 / 01", "01 / 10").replace("MON", "SAT")
+            result = self.crawler._parse_detail_html(html, "https://shibuya-o.com/nest/schedule/test/")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["date"], "2027-01-10")
+
+    def test_extract_performance_schedules_returns_empty(self):
+        # extract_performance_schedules is not used — process_performance_schedules overrides
+        result = self.crawler.extract_performance_schedules("")
+        self.assertEqual(result, [])
+
+    def test_fetch_all_schedules_via_api_pagination(self):
+        mock_posts_page1 = [
+            {"link": "https://shibuya-o.com/nest/schedule/event-a/"},
+        ]
+        mock_posts_page2 = [
+            {"link": "https://shibuya-o.com/nest/schedule/event-b/"},
+        ]
+
+        detail_a = DETAIL_HTML_FULL
+        detail_b = DETAIL_HTML_NO_PERFORMERS
+
+        def mock_get(url: str, **_kwargs: object) -> MagicMock:
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if "&page=1" in url:
+                resp.json.return_value = mock_posts_page1
+                resp.headers = {"X-WP-TotalPages": "2"}
+                resp.status_code = 200
+            elif "&page=2" in url:
+                resp.json.return_value = mock_posts_page2
+                resp.headers = {"X-WP-TotalPages": "2"}
+                resp.status_code = 200
+            elif "event-a" in url:
+                resp.text = detail_a
+                resp.status_code = 200
+            else:
+                resp.text = detail_b
+                resp.status_code = 200
+            return resp
+
+        self.crawler.session.get = mock_get
+        with patch.object(timezone, "localdate", return_value=timezone.datetime(2026, 5, 1).date()):
+            schedules = self.crawler._fetch_all_schedules_via_api()
+
+        self.assertEqual(len(schedules), 2)
+        dates = [s["date"] for s in schedules]
+        self.assertIn("2026-05-14", dates)
+        self.assertIn("2026-06-01", dates)


### PR DESCRIPTION
## Summary

- Adds `ShibuyaONestCrawler` in `malcom/houses/crawlers/shibuya_o_nest.py`
- Registers via `@CrawlerRegistry.register("ShibuyaONestCrawler")`
- The schedule list page is JavaScript-rendered; events are enumerated via the WordPress REST API (`/wp-json/wp/v2/nest-schedule`, paginated with `X-WP-TotalPages`)
- Each event's detail page is server-rendered HTML — parsed with BeautifulSoup for date (`MM / DD`), OPEN/START times, performers (`出演：A / B / C`), and event image (`img.wp-post-image`)
- Year rollover handled: Nov/Dec → Jan/Feb events assigned to `year+1`
- 10 unit tests covering date parsing, time extraction, performer fallback, year rollover, image extraction, pagination, and missing-date guard

## Test plan

- [x] `uv run python manage.py test houses.tests.test_crawlers_shibuya_o_nest` — 10/10 pass
- [x] `ruff check` — clean
- [ ] Register venue via `addwebsite https://shibuya-o.com/nest/` and run `collect_schedules` against live site
- [ ] Verify `PerformanceSchedule` records created correctly

Closes #70