### PR TITLE
feat(video): add YouTube Shorts (9:16, ≤60s) output mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,9 +126,9 @@ All commands must be run from the `malcom/` directory: `cd malcom && uv run pyth
 | Command | Purpose | Key Options |
 |---------|---------|-------------|
 | `generate_weekly_playlist_introduction` | Generate AI narration for weekly video | `<playlist_id>`, `--audio`, `--voice` |
-| `generate_weekly_playlist_video` | Create weekly playlist video (auto-generates narration) | `<playlist_id>`, `--intro-text-file` |
+| `generate_weekly_playlist_video` | Create weekly playlist video (auto-generates narration) | `<playlist_id>`, `--intro-text-file`, `--format {standard,shorts}` |
 | `generate_playlist_introduction` | Generate AI narration for monthly video | `<target_month>` |
-| `generate_playlist_video` | Create monthly playlist video | `<target_month>` |
+| `generate_playlist_video` | Create monthly playlist video | `<target_month>`, `--format {standard,shorts}` |
 | `generate_tts_samples` | Generate TTS audio samples with different tunings | `--count`, `--text`, `--output-dir`, `--voice` |
 
 **Weekly video workflow:**

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -77,6 +77,7 @@ consistent across the two pipelines.
 |----------|------|-----|
 | `INSTAGRAM_SQUARE` | `(1080, 1080)` | All carousel slides. |
 | `VIDEO_WIDESCREEN` | `(1920, 1080)` | Playlist video slides. |
+| `VIDEO_SHORTS` | `(1080, 1920)` | YouTube Shorts slides (9:16 vertical). |
 
 ## Layout helpers
 
@@ -124,6 +125,24 @@ In `malcom/houses/functions.py`:
 The video generator (`_generate_playlist_video`) uses **hard cuts** between
 slides — the previous glitch/RGB-shift transitions were retired with this
 design pass. They fought the warm analog idiom.
+
+### YouTube Shorts (1080×1920)
+
+In `malcom/houses/functions.py`:
+
+| Function | Purpose |
+|----------|---------|
+| `render_shorts_intro_slide` | Vertical editorial header + stacked single-column numbered lineup (vermillion numerals + cream names, ★ for spotlights). Corner wordmark bottom-left. |
+| `render_shorts_performer_slide` | Top: oversized vermillion position numeral. Middle: display-serif name + romaji + song title + venue/date. Bottom: single centered cream QR card (artist link). |
+| `render_shorts_closing_slide` | Centered display-serif closing message stacked above a cream YouTube channel QR card. |
+
+The Shorts coordinator (`_generate_playlist_video_shorts`) holds the runtime
+under 60s by capping performer slides and using shorter fixed per-slide
+durations (intro 3s, performer 4s, closing 3s — the ≤60s budget supports
+up to 12 performer slides). Audio is background music only — the
+long-form narration TTS is intentionally skipped because Shorts pacing
+will not let a multi-minute voiceover fit. The video is rendered at 30fps
+with H.264 + AAC, the standard codecs accepted by YouTube Shorts uploads.
 
 ## Adding a new slide
 

--- a/malcom/commons/design.py
+++ b/malcom/commons/design.py
@@ -50,6 +50,7 @@ SP_XXL = 144
 # --- Canvas sizes ---
 INSTAGRAM_SQUARE = (1080, 1080)
 VIDEO_WIDESCREEN = (1920, 1080)
+VIDEO_SHORTS = (1080, 1920)  # 9:16 vertical, for YouTube Shorts
 
 # --- Fonts ---
 _FONTS_DIR = Path(__file__).resolve().parent / "fonts"

--- a/malcom/houses/functions.py
+++ b/malcom/houses/functions.py
@@ -38,7 +38,7 @@ from django.db.models import Count
 from django.utils import timezone
 from moviepy import AudioFileClip, CompositeAudioClip, ImageClip, concatenate_audioclips, concatenate_videoclips
 from moviepy.audio import fx as afx
-from performers.models import Performer, PerformerSocialLink
+from performers.models import Performer, PerformerSocialLink, PerformerSong
 from PIL import Image, ImageDraw
 from pydub import AudioSegment
 from pydub.generators import WhiteNoise
@@ -831,6 +831,49 @@ SHORTS_INTRO_DURATION = 3.0
 SHORTS_PERFORMER_DURATION = 4.0
 SHORTS_CLOSING_DURATION = 3.0
 SHORTS_MAX_TOTAL_DURATION = 60.0
+SHORTS_AUDIO_FADE_DURATION = 0.5
+PERFORMER_SAMPLES_DIR = "performer_samples"
+
+
+def download_performer_song_audio(song: PerformerSong, *, force: bool = False) -> Path | None:
+    """Download audio from a performer's YouTube song, caching to data/performer_samples/<song_id>.mp3.
+
+    Returns the cached path, or None if the song has no YouTube URL or download fails.
+    """
+    if not song.youtube_url:
+        return None
+
+    import yt_dlp  # noqa: PLC0415
+
+    samples_dir = Path(settings.BASE_DIR) / "data" / PERFORMER_SAMPLES_DIR
+    samples_dir.mkdir(parents=True, exist_ok=True)
+    output_path = samples_dir / f"{song.id}.mp3"
+
+    if output_path.exists() and not force:
+        return output_path
+
+    ydl_opts = {
+        "format": "bestaudio/best",
+        "postprocessors": [
+            {
+                "key": "FFmpegExtractAudio",
+                "preferredcodec": "mp3",
+                "preferredquality": "192",
+            }
+        ],
+        "outtmpl": str(samples_dir / f"{song.id}.%(ext)s"),
+        "quiet": True,
+        "no_warnings": True,
+    }
+    try:
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([song.youtube_url])
+        if output_path.exists():
+            logger.info(f"Downloaded audio for {song.performer.name}: {output_path}")
+            return output_path
+    except Exception:  # noqa: BLE001
+        logger.exception(f"Failed to download audio for song id={song.id} ({song.youtube_url})")
+    return None
 
 
 def render_shorts_intro_slide(
@@ -1357,7 +1400,7 @@ def generate_weekly_playlist_video(playlist: WeeklyPlaylist, intro_text: str | N
     )
 
 
-def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915
+def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915, C901
     playlist: MonthlyPlaylist | WeeklyPlaylist,
     entry_set_name: str,
     date_start: dt.date,
@@ -1400,8 +1443,9 @@ def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915
     intro_slide.save(intro_path)
     slides.append((intro_path, SHORTS_INTRO_DURATION))
 
-    # 2. Performer slides
+    # 2. Performer slides — collect (path, duration, song) so we can build per-performer audio
     logger.info(f"Creating {len(entries)} shorts performer slides...")
+    performer_entries: list[tuple[Path, float, PerformerSong | None]] = []
     for entry in entries:
         performer = entry.song.performer
 
@@ -1429,6 +1473,7 @@ def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915
         performer_path = temp_dir / f"shorts_performer_{entry.position:02d}.png"
         performer_slide.save(performer_path)
         slides.append((performer_path, SHORTS_PERFORMER_DURATION))
+        performer_entries.append((performer_path, SHORTS_PERFORMER_DURATION, entry.song))
 
     # 3. Closing slide
     logger.info("Creating shorts closing slide...")
@@ -1444,23 +1489,70 @@ def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915
     video_clips = [ImageClip(str(path)).with_duration(duration) for path, duration in slides]
     final_video = concatenate_videoclips(video_clips, method="compose")
 
-    # Background music only — no narration TTS to keep runtime under 60s deterministically.
+    # Build audio: background music for intro/closing; per-performer song during each performer slide.
     background_music_path = (
         Path(settings.BASE_DIR) / "data" / "get-in-the-groove-psychedelic-grunge-instrumental-391304.mp3"
     )
-    if background_music_path.exists():
-        try:
-            logger.info(f"Adding background music: {background_music_path}")
-            background_music = AudioFileClip(str(background_music_path))
-            if background_music.duration < final_video.duration:
-                loops_needed = int(final_video.duration / background_music.duration) + 1
-                background_music = concatenate_audioclips([background_music] * loops_needed)
-            background_music = background_music.subclipped(0, final_video.duration)
-            background_music = background_music.with_volume_scaled(0.5)
-            background_music = background_music.with_effects([afx.AudioFadeOut(2.0)])
-            final_video = final_video.with_audio(background_music)
-        except Exception:  # noqa: BLE001
-            logger.exception("Failed to add background music, continuing without it")
+    try:
+        audio_clips = []
+
+        # Helper: loop a clip to at least `target_duration` seconds
+        def _loop_to_duration(clip: AudioFileClip, target_duration: float) -> AudioFileClip:
+            if clip.duration < target_duration:
+                loops = int(target_duration / clip.duration) + 1
+                clip = concatenate_audioclips([clip] * loops)
+            return clip.subclipped(0, target_duration)
+
+        # Intro: background music at low volume
+        if background_music_path.exists():
+            bg_intro = AudioFileClip(str(background_music_path))
+            bg_intro = _loop_to_duration(bg_intro, SHORTS_INTRO_DURATION)
+            bg_intro = bg_intro.with_volume_scaled(0.4).with_start(0)
+            audio_clips.append(bg_intro)
+
+        # Performer slides: each gets their own song (fade in / fade out within the slide window)
+        performer_offset = SHORTS_INTRO_DURATION
+        for _slide_path, slide_duration, song in performer_entries:
+            song_path = download_performer_song_audio(song) if song else None
+            if song_path and song_path.exists():
+                try:
+                    perf_audio = AudioFileClip(str(song_path))
+                    perf_audio = _loop_to_duration(perf_audio, slide_duration)
+                    perf_audio = perf_audio.with_effects(
+                        [
+                            afx.AudioFadeIn(SHORTS_AUDIO_FADE_DURATION),
+                            afx.AudioFadeOut(SHORTS_AUDIO_FADE_DURATION),
+                        ]
+                    )
+                    audio_clips.append(perf_audio.with_start(performer_offset))
+                    logger.info(f"Added audio for {song.performer.name} at t={performer_offset:.1f}s")
+                except Exception:  # noqa: BLE001
+                    logger.exception(f"Failed to load audio for {song.performer.name}, skipping")
+            # Fallback: background music segment for this slide
+            elif background_music_path.exists():
+                try:
+                    bg_seg = AudioFileClip(str(background_music_path))
+                    bg_seg = _loop_to_duration(bg_seg, slide_duration)
+                    bg_seg = bg_seg.with_volume_scaled(0.4).with_start(performer_offset)
+                    audio_clips.append(bg_seg)
+                except Exception:  # noqa: BLE001
+                    logger.exception("Failed to add fallback background segment")
+            performer_offset += slide_duration
+
+        # Closing: background music with fade-out
+        if background_music_path.exists():
+            bg_closing = AudioFileClip(str(background_music_path))
+            bg_closing = _loop_to_duration(bg_closing, SHORTS_CLOSING_DURATION)
+            bg_closing = bg_closing.with_volume_scaled(0.4)
+            bg_closing = bg_closing.with_effects([afx.AudioFadeOut(SHORTS_CLOSING_DURATION * 0.8)])
+            audio_clips.append(bg_closing.with_start(performer_offset))
+
+        if audio_clips:
+            composite_audio = CompositeAudioClip(audio_clips)
+            final_video = final_video.with_audio(composite_audio)
+
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to build audio track, rendering without audio")
 
     video_dir = Path(settings.BASE_DIR) / "data" / "videos"
     video_dir.mkdir(parents=True, exist_ok=True)

--- a/malcom/houses/functions.py
+++ b/malcom/houses/functions.py
@@ -22,6 +22,7 @@ from commons.design import (
     SP_MD,
     SP_SM,
     SP_XL,
+    VIDEO_SHORTS,
     VIDEO_WIDESCREEN,
     body_font,
     brand_wash_canvas,
@@ -825,6 +826,217 @@ def render_video_closing_slide(closing_text: str, channel_url: str) -> Image.Ima
     return canvas
 
 
+SHORTS_MAX_PERFORMERS = 12
+SHORTS_INTRO_DURATION = 3.0
+SHORTS_PERFORMER_DURATION = 4.0
+SHORTS_CLOSING_DURATION = 3.0
+SHORTS_MAX_TOTAL_DURATION = 60.0
+
+
+def render_shorts_intro_slide(
+    title_label: str,
+    lineup: list[tuple[int, str, bool]],
+) -> Image.Image:
+    """Render the opening slide of a YouTube Shorts playlist video (9:16, 1080×1920).
+
+    Layout:
+      - Top stack: editorial label + display-serif title + period
+      - Stacked numbered lineup (single column), vermillion numerals + cream names
+      - Spotlighted performers get a small ★ marker
+      - Corner wordmark bottom-left
+    """
+    canvas = brand_wash_canvas(VIDEO_SHORTS)
+    draw = ImageDraw.Draw(canvas)
+    video_w, video_h = VIDEO_SHORTS
+
+    label_font = body_font(28, bold=True)
+    draw.text((SP_LG, SP_LG), "HAKKO-AKKEI // TOKYO LIVE HOUSES", font=label_font, fill=INK_GRAY)
+
+    title_font = display_font(96)
+    draw.text((SP_LG, SP_LG + 48), title_label, font=title_font, fill=AGED_CREAM)
+
+    # Top-N stacked lineup
+    list_top = 280
+    list_bottom = video_h - 180
+    list_h = list_bottom - list_top
+    entries = lineup[:SHORTS_MAX_PERFORMERS]
+    if entries:
+        line_h = list_h // len(entries)
+        line_h = max(64, min(line_h, 110))
+        num_font = display_font(int(line_h * 0.78))
+        name_font = display_font(int(line_h * 0.5))
+        max_name_w = video_w - SP_LG * 2 - 130
+
+        for i, (pos, name, spotlight) in enumerate(entries):
+            y = list_top + i * line_h
+            draw.text(
+                (SP_LG, y + line_h // 2),
+                f"{pos:02d}",
+                font=num_font,
+                fill=FLYER_RED,
+                anchor="lm",
+            )
+            display_name = name + (" ★" if spotlight else "")
+            lines = wrap_text(draw, display_name, name_font, max_name_w)
+            if lines:
+                draw.text(
+                    (SP_LG + 130, y + line_h // 2),
+                    lines[0],
+                    font=name_font,
+                    fill=AGED_CREAM,
+                    anchor="lm",
+                )
+
+    draw_corner_wordmark(draw, (SP_LG, video_h - SP_LG), anchor="lb", color=INK_GRAY, size=20)
+    return canvas
+
+
+def render_shorts_performer_slide(  # noqa: PLR0913
+    position: int,
+    performer: Performer,
+    song_title: str,
+    venue_name: str | None,
+    performance_date: dt.date | None,
+    artist_url: str | None,
+) -> Image.Image:
+    """Render a single performer slide for a Shorts playlist video.
+
+    Layout (1080×1920):
+      - Top section: oversized vermillion position numeral
+      - Middle section: display-serif performer name + romaji subtitle + song title
+      - Lower-middle section: venue + date metadata
+      - Bottom QR card (artist link only — single QR fits the punchy Shorts pacing)
+      - Corner wordmark
+    """
+    canvas = brand_wash_canvas(VIDEO_SHORTS)
+    draw = ImageDraw.Draw(canvas)
+    video_w, video_h = VIDEO_SHORTS
+
+    label_font = body_font(26, bold=True)
+    draw.text((SP_LG, SP_LG), "PERFORMER // NOW PLAYING", font=label_font, fill=INK_GRAY)
+
+    numeral_font = display_font(360)
+    draw.text((SP_LG, SP_LG + 30), f"{position:02d}", font=numeral_font, fill=FLYER_RED, anchor="lt")
+
+    text_left = SP_LG
+    text_max_w = video_w - SP_LG * 2
+    cursor_y = SP_LG + 420
+
+    name_font = display_font(96)
+    name_lines = wrap_text(draw, performer.name, name_font, text_max_w)
+    for line in name_lines[:2]:
+        draw.text((text_left, cursor_y), line, font=name_font, fill=AGED_CREAM, anchor="lt")
+        cursor_y += 104
+
+    if performer.name_romaji and performer.name_romaji.lower() != performer.name.lower():
+        romaji_font = body_font(36)
+        draw.text((text_left, cursor_y), performer.name_romaji, font=romaji_font, fill=INK_GRAY, anchor="lt")
+        cursor_y += 48
+
+    if song_title:
+        song_font = body_font(32)
+        draw.text((text_left, cursor_y + SP_SM), f'"{song_title}"', font=song_font, fill=AGED_CREAM, anchor="lt")
+        cursor_y += SP_SM + 42
+
+    if performance_date:
+        date_font = body_font(32, bold=True)
+        draw.text(
+            (text_left, cursor_y + SP_MD),
+            performance_date.strftime("%a %b %d, %Y").upper(),
+            font=date_font,
+            fill=FLYER_RED,
+            anchor="lt",
+        )
+        cursor_y += SP_MD + 42
+
+    if venue_name:
+        venue_font = body_font(32, bold=True)
+        venue_lines = wrap_text(draw, venue_name, venue_font, text_max_w)
+        for line in venue_lines[:2]:
+            draw.text((text_left, cursor_y), line, font=venue_font, fill=AGED_CREAM, anchor="lt")
+            cursor_y += 42
+
+    if artist_url:
+        card_size = 380
+        card_x = (video_w - card_size) // 2
+        card_y = video_h - card_size - SP_XL
+        canvas_rgba = canvas.convert("RGBA")
+        panel = Image.new("RGBA", (card_size, card_size), AGED_CREAM_PANEL)
+        canvas_rgba.alpha_composite(panel, (card_x, card_y))
+        canvas = canvas_rgba.convert("RGB")
+        draw = ImageDraw.Draw(canvas)
+
+        inner = card_size - 2 * SP_MD - 36
+        qr_img = build_qr_code(artist_url, inner)
+        canvas.paste(qr_img, (card_x + (card_size - inner) // 2, card_y + SP_MD))
+
+        qr_label_font = body_font(22, bold=True)
+        draw.text(
+            (card_x + card_size // 2, card_y + card_size - SP_MD),
+            "ARTIST",
+            font=qr_label_font,
+            fill=PAPER_BLACK,
+            anchor="mb",
+        )
+
+    draw_corner_wordmark(draw, (SP_LG, video_h - SP_LG), anchor="lb", color=INK_GRAY, size=20)
+    return canvas
+
+
+def render_shorts_closing_slide(closing_text: str, channel_url: str) -> Image.Image:
+    """Render the closing slide of a Shorts playlist video.
+
+    Layout (1080×1920): centered display-serif message stacked above a cream
+    QR card linking the YouTube channel.
+    """
+    canvas = brand_wash_canvas(VIDEO_SHORTS)
+    draw = ImageDraw.Draw(canvas)
+    video_w, video_h = VIDEO_SHORTS
+
+    label_font = body_font(28, bold=True)
+    draw.text((video_w // 2, SP_LG), "HAKKO-AKKEI // SUBSCRIBE", font=label_font, fill=INK_GRAY, anchor="mt")
+
+    closing_font = display_font(108)
+    closing_lines = wrap_text(draw, closing_text, closing_font, video_w - 2 * SP_LG)
+    msg_top = 280
+    for line in closing_lines[:3]:
+        draw.text((video_w // 2, msg_top), line, font=closing_font, fill=AGED_CREAM, anchor="mt")
+        msg_top += 124
+
+    follow_font = body_font(34, bold=True)
+    draw.text(
+        (video_w // 2, msg_top + SP_MD),
+        "Follow @hakkoakkei",
+        font=follow_font,
+        fill=FLYER_RED,
+        anchor="mt",
+    )
+
+    card_size = 460
+    card_x = (video_w - card_size) // 2
+    card_y = video_h - card_size - SP_XL
+    canvas_rgba = canvas.convert("RGBA")
+    panel = Image.new("RGBA", (card_size, card_size), AGED_CREAM_PANEL)
+    canvas_rgba.alpha_composite(panel, (card_x, card_y))
+    canvas = canvas_rgba.convert("RGB")
+    draw = ImageDraw.Draw(canvas)
+
+    qr_inner = card_size - 2 * SP_MD - 36
+    qr_img = build_qr_code(channel_url, qr_inner)
+    canvas.paste(qr_img, (card_x + (card_size - qr_inner) // 2, card_y + SP_MD))
+
+    qr_label_font = body_font(22, bold=True)
+    draw.text(
+        (card_x + card_size // 2, card_y + card_size - SP_MD),
+        "YOUTUBE CHANNEL",
+        font=qr_label_font,
+        fill=PAPER_BLACK,
+        anchor="mb",
+    )
+
+    return canvas
+
+
 def _generate_playlist_video(  # noqa: C901, PLR0915, PLR0912
     playlist: MonthlyPlaylist | WeeklyPlaylist,
     intro_text_func: Callable,
@@ -1142,4 +1354,163 @@ def generate_weekly_playlist_video(playlist: WeeklyPlaylist, intro_text: str | N
         filename_prefix="playlist_intro_week_",
         timestamp_format="%Y%m%d",
         intro_text=intro_text,
+    )
+
+
+def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915
+    playlist: MonthlyPlaylist | WeeklyPlaylist,
+    entry_set_name: str,
+    date_start: dt.date,
+    date_end: dt.date,
+    title_label: str,
+    closing_text: str,
+    filename_prefix: str,
+    timestamp_format: str,
+    max_performers: int = SHORTS_MAX_PERFORMERS,
+) -> Path:
+    """Generate a vertical 9:16 YouTube Shorts video (≤60s) from a playlist.
+
+    Shorts pacing keeps the runtime under 60s by capping the number of
+    performer slides and using shorter fixed durations per slide. Audio is
+    background music only — narration is the long-form video's job.
+    """
+    temp_dir = Path(tempfile.mkdtemp())
+    logger.info(f"Created temp directory: {temp_dir}")
+
+    entry_set = getattr(playlist, entry_set_name).select_related("song__performer")
+    all_entries = list(entry_set.order_by("position"))
+
+    # Budget: leave room for intro + closing inside SHORTS_MAX_TOTAL_DURATION.
+    budget = SHORTS_MAX_TOTAL_DURATION - SHORTS_INTRO_DURATION - SHORTS_CLOSING_DURATION
+    capacity_by_duration = int(budget // SHORTS_PERFORMER_DURATION)
+    cap = max(1, min(max_performers, capacity_by_duration))
+    entries = all_entries[:cap]
+    if len(all_entries) > cap:
+        logger.info(f"Shorts: capping performer slides at {cap} of {len(all_entries)} to fit 60s budget")
+
+    slides: list[tuple[Path, float]] = []
+
+    # 1. Intro slide
+    logger.info("Creating shorts intro slide...")
+    intro_lineup: list[tuple[int, str, bool]] = [
+        (entry.position, entry.song.performer.name, entry.is_spotlight) for entry in entries
+    ]
+    intro_slide = render_shorts_intro_slide(title_label=title_label, lineup=intro_lineup)
+    intro_path = temp_dir / "shorts_intro.png"
+    intro_slide.save(intro_path)
+    slides.append((intro_path, SHORTS_INTRO_DURATION))
+
+    # 2. Performer slides
+    logger.info(f"Creating {len(entries)} shorts performer slides...")
+    for entry in entries:
+        performer = entry.song.performer
+
+        performance = (
+            PerformanceSchedule.objects.filter(
+                performers=performer,
+                performance_date__gte=date_start,
+                performance_date__lt=date_end,
+            )
+            .select_related("live_house", "live_house__website")
+            .first()
+        )
+        artist_url = performer.website if performer.website else entry.song.youtube_url
+        venue_name = performance.live_house.name if performance else None
+        perf_date = performance.performance_date if performance else None
+
+        performer_slide = render_shorts_performer_slide(
+            position=entry.position,
+            performer=performer,
+            song_title=entry.song.title or "",
+            venue_name=venue_name,
+            performance_date=perf_date,
+            artist_url=artist_url,
+        )
+        performer_path = temp_dir / f"shorts_performer_{entry.position:02d}.png"
+        performer_slide.save(performer_path)
+        slides.append((performer_path, SHORTS_PERFORMER_DURATION))
+
+    # 3. Closing slide
+    logger.info("Creating shorts closing slide...")
+    closing_slide = render_shorts_closing_slide(
+        closing_text=closing_text,
+        channel_url="https://www.youtube.com/@hakkoakkei",
+    )
+    closing_path = temp_dir / "shorts_closing.png"
+    closing_slide.save(closing_path)
+    slides.append((closing_path, SHORTS_CLOSING_DURATION))
+
+    # Compose video clips (hard cuts, vertical canvas already baked into the PNGs)
+    video_clips = [ImageClip(str(path)).with_duration(duration) for path, duration in slides]
+    final_video = concatenate_videoclips(video_clips, method="compose")
+
+    # Background music only — no narration TTS to keep runtime under 60s deterministically.
+    background_music_path = (
+        Path(settings.BASE_DIR) / "data" / "get-in-the-groove-psychedelic-grunge-instrumental-391304.mp3"
+    )
+    if background_music_path.exists():
+        try:
+            logger.info(f"Adding background music: {background_music_path}")
+            background_music = AudioFileClip(str(background_music_path))
+            if background_music.duration < final_video.duration:
+                loops_needed = int(final_video.duration / background_music.duration) + 1
+                background_music = concatenate_audioclips([background_music] * loops_needed)
+            background_music = background_music.subclipped(0, final_video.duration)
+            background_music = background_music.with_volume_scaled(0.5)
+            background_music = background_music.with_effects([afx.AudioFadeOut(2.0)])
+            final_video = final_video.with_audio(background_music)
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to add background music, continuing without it")
+
+    video_dir = Path(settings.BASE_DIR) / "data" / "videos"
+    video_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = playlist.date.strftime(timestamp_format)
+    video_filename = f"{filename_prefix}{timestamp}.mp4"
+    video_filepath = video_dir / video_filename
+
+    logger.info(f"Rendering shorts video to {video_filepath} (duration={final_video.duration:.1f}s)...")
+    final_video.write_videofile(
+        str(video_filepath),
+        fps=30,
+        codec="libx264",
+        audio_codec="aac",
+        temp_audiofile=str(temp_dir / "temp_audio.m4a"),
+        remove_temp=True,
+    )
+    logger.info(f"Shorts video generation complete: {video_filepath}")
+    return video_filepath
+
+
+def generate_playlist_video_shorts(playlist: MonthlyPlaylist, max_performers: int = SHORTS_MAX_PERFORMERS) -> Path:
+    """Generate a YouTube Shorts (9:16, ≤60s) video for a monthly playlist."""
+    month_start = playlist.date
+    return _generate_playlist_video_shorts(
+        playlist=playlist,
+        entry_set_name="monthlyplaylistentry_set",
+        date_start=month_start,
+        date_end=get_month_end(month_start),
+        title_label=playlist.date.strftime("%B %Y"),
+        closing_text="See You Next Month!",
+        filename_prefix="playlist_shorts_",
+        timestamp_format="%Y%m",
+        max_performers=max_performers,
+    )
+
+
+def generate_weekly_playlist_video_shorts(
+    playlist: WeeklyPlaylist,
+    max_performers: int = SHORTS_MAX_PERFORMERS,
+) -> Path:
+    """Generate a YouTube Shorts (9:16, ≤60s) video for a weekly playlist."""
+    week_start = playlist.date
+    return _generate_playlist_video_shorts(
+        playlist=playlist,
+        entry_set_name="weeklyplaylistentry_set",
+        date_start=week_start,
+        date_end=week_start + timezone.timedelta(days=7),
+        title_label=f"Week of {playlist.date.strftime('%Y-%m-%d')}",
+        closing_text="See You Next Week!",
+        filename_prefix="playlist_shorts_week_",
+        timestamp_format="%Y%m%d",
+        max_performers=max_performers,
     )

--- a/malcom/houses/management/commands/generate_performer_sample.py
+++ b/malcom/houses/management/commands/generate_performer_sample.py
@@ -1,0 +1,121 @@
+"""Download performer song audio samples from YouTube for use in Shorts videos."""
+
+import logging
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandParser
+from houses.functions import PERFORMER_SAMPLES_DIR, download_performer_song_audio
+from houses.models import MonthlyPlaylist, WeeklyPlaylist
+from performers.models import Performer
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Download performer song audio samples from their registered YouTube song items. "
+        "Cached files are saved to data/performer_samples/<song_id>.mp3 and reused by "
+        "generate_playlist_video --format shorts."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            "--monthly-playlist-id",
+            type=int,
+            help="Download samples for all performers in a monthly playlist",
+        )
+        group.add_argument(
+            "--weekly-playlist-id",
+            type=int,
+            help="Download samples for all performers in a weekly playlist",
+        )
+        group.add_argument(
+            "--performer-id",
+            type=int,
+            help="Download sample for a single performer",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Re-download even if a cached sample already exists",
+        )
+
+    def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003
+        force: bool = options["force"]
+        samples_dir = Path(settings.BASE_DIR) / "data" / PERFORMER_SAMPLES_DIR
+        samples_dir.mkdir(parents=True, exist_ok=True)
+
+        songs = self._resolve_songs(options)
+        if not songs:
+            self.stderr.write(self.style.ERROR("No songs found for the given arguments."))
+            return
+
+        self.stdout.write(f"Processing {len(songs)} song(s). Cache dir: {samples_dir}\n")
+        ok = 0
+        skipped = 0
+        failed = 0
+
+        for song in songs:
+            if not song.youtube_url:
+                self.stdout.write(f"  SKIP  {song.performer.name} — no YouTube URL registered")
+                skipped += 1
+                continue
+
+            cached = samples_dir / f"{song.id}.mp3"
+            if cached.exists() and not force:
+                self.stdout.write(f"  CACHE {song.performer.name}: {cached.name}")
+                ok += 1
+                continue
+
+            self.stdout.write(f"  DL    {song.performer.name}: {song.youtube_url}")
+            result = download_performer_song_audio(song, force=force)
+            if result:
+                self.stdout.write(self.style.SUCCESS(f"         → {result.name}"))
+                ok += 1
+            else:
+                self.stderr.write(self.style.ERROR("         ✗ download failed"))
+                failed += 1
+
+        self.stdout.write(f"\nDone — ok: {ok}  skipped: {skipped}  failed: {failed}")
+
+    def _resolve_songs(self, options: dict) -> list:  # noqa: ANN001, PLR0911
+        monthly_id: int | None = options.get("monthly_playlist_id")
+        weekly_id: int | None = options.get("weekly_playlist_id")
+        performer_id: int | None = options.get("performer_id")
+
+        if monthly_id is not None:
+            try:
+                playlist = MonthlyPlaylist.objects.get(id=monthly_id)
+            except MonthlyPlaylist.DoesNotExist:
+                self.stderr.write(self.style.ERROR(f"MonthlyPlaylist id={monthly_id} not found"))
+                return []
+            return [
+                entry.song
+                for entry in playlist.monthlyplaylistentry_set.select_related("song__performer").order_by("position")
+            ]
+
+        if weekly_id is not None:
+            try:
+                playlist = WeeklyPlaylist.objects.get(id=weekly_id)
+            except WeeklyPlaylist.DoesNotExist:
+                self.stderr.write(self.style.ERROR(f"WeeklyPlaylist id={weekly_id} not found"))
+                return []
+            return [
+                entry.song
+                for entry in playlist.weeklyplaylistentry_set.select_related("song__performer").order_by("position")
+            ]
+
+        if performer_id is not None:
+            try:
+                performer = Performer.objects.get(id=performer_id)
+            except Performer.DoesNotExist:
+                self.stderr.write(self.style.ERROR(f"Performer id={performer_id} not found"))
+                return []
+            songs = list(performer.songs.filter(youtube_url__gt="").order_by("id"))
+            if not songs:
+                self.stderr.write(self.style.WARNING(f"Performer {performer.name} has no songs with a YouTube URL"))
+            return songs
+
+        return []

--- a/malcom/houses/management/commands/generate_performer_sample.py
+++ b/malcom/houses/management/commands/generate_performer_sample.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandParser
 from houses.functions import PERFORMER_SAMPLES_DIR, download_performer_song_audio
 from houses.models import MonthlyPlaylist, WeeklyPlaylist
-from performers.models import Performer
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +30,11 @@ class Command(BaseCommand):
             type=int,
             help="Download samples for all performers in a weekly playlist",
         )
-        group.add_argument(
+        parser.add_argument(
             "--performer-id",
             type=int,
-            help="Download sample for a single performer",
+            default=None,
+            help="If given, download the sample for only this performer in the playlist",
         )
         parser.add_argument(
             "--force",
@@ -80,7 +80,7 @@ class Command(BaseCommand):
 
         self.stdout.write(f"\nDone — ok: {ok}  skipped: {skipped}  failed: {failed}")
 
-    def _resolve_songs(self, options: dict) -> list:  # noqa: ANN001, PLR0911
+    def _resolve_songs(self, options: dict) -> list:  # noqa: ANN001
         monthly_id: int | None = options.get("monthly_playlist_id")
         weekly_id: int | None = options.get("weekly_playlist_id")
         performer_id: int | None = options.get("performer_id")
@@ -91,31 +91,24 @@ class Command(BaseCommand):
             except MonthlyPlaylist.DoesNotExist:
                 self.stderr.write(self.style.ERROR(f"MonthlyPlaylist id={monthly_id} not found"))
                 return []
-            return [
+            songs = [
                 entry.song
                 for entry in playlist.monthlyplaylistentry_set.select_related("song__performer").order_by("position")
             ]
-
-        if weekly_id is not None:
+        elif weekly_id is not None:
             try:
                 playlist = WeeklyPlaylist.objects.get(id=weekly_id)
             except WeeklyPlaylist.DoesNotExist:
                 self.stderr.write(self.style.ERROR(f"WeeklyPlaylist id={weekly_id} not found"))
                 return []
-            return [
+            songs = [
                 entry.song
                 for entry in playlist.weeklyplaylistentry_set.select_related("song__performer").order_by("position")
             ]
+        else:
+            return []
 
         if performer_id is not None:
-            try:
-                performer = Performer.objects.get(id=performer_id)
-            except Performer.DoesNotExist:
-                self.stderr.write(self.style.ERROR(f"Performer id={performer_id} not found"))
-                return []
-            songs = list(performer.songs.filter(youtube_url__gt="").order_by("id"))
-            if not songs:
-                self.stderr.write(self.style.WARNING(f"Performer {performer.name} has no songs with a YouTube URL"))
-            return songs
+            songs = [s for s in songs if s.performer.id == performer_id]
 
-        return []
+        return songs

--- a/malcom/houses/management/commands/generate_playlist_video.py
+++ b/malcom/houses/management/commands/generate_playlist_video.py
@@ -3,8 +3,11 @@
 from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandParser
-from houses.functions import generate_playlist_video
+from houses.functions import generate_playlist_video, generate_playlist_video_shorts
 from houses.models import MonthlyPlaylist
+
+VIDEO_FORMAT_STANDARD = "standard"
+VIDEO_FORMAT_SHORTS = "shorts"
 
 
 class Command(BaseCommand):
@@ -21,11 +24,22 @@ class Command(BaseCommand):
             type=str,
             help="Path to UTF-8 text file containing pre-written introduction text",
         )
+        parser.add_argument(
+            "--format",
+            choices=[VIDEO_FORMAT_STANDARD, VIDEO_FORMAT_SHORTS],
+            default=VIDEO_FORMAT_STANDARD,
+            dest="video_format",
+            help=(
+                "Output format: 'standard' for 1920x1080 long-form, "
+                "'shorts' for 1080x1920 9:16 ≤60s YouTube Shorts (no narration)"
+            ),
+        )
 
     def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003
         """Generate and save playlist introduction video."""
         playlist_id = options["playlist_id"]
         intro_text_file = options.get("intro_text_file")
+        video_format = options["video_format"]
 
         try:
             playlist = MonthlyPlaylist.objects.get(id=playlist_id)
@@ -35,6 +49,13 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Generating video for playlist: {playlist.date.strftime('%B %Y')}")
         self.stdout.write(f"Playlist URL: {playlist.youtube_playlist_url}")
+
+        if video_format == VIDEO_FORMAT_SHORTS:
+            self.stdout.write("Format: shorts (9:16, ≤60s, no narration)")
+            shorts_filepath = generate_playlist_video_shorts(playlist)
+            self.stdout.write(self.style.SUCCESS("\n=== Shorts Video Generated ===\n"))
+            self.stdout.write(f"Video saved to: {shorts_filepath}")
+            return
 
         # Load introduction text from file if provided
         intro_text = None

--- a/malcom/houses/management/commands/generate_weekly_playlist_video.py
+++ b/malcom/houses/management/commands/generate_weekly_playlist_video.py
@@ -5,8 +5,11 @@ from pathlib import Path
 from commons.youtube_utils import insert_video_at_position, upload_video_to_youtube
 from django.core.management.base import BaseCommand, CommandParser
 from django.utils import timezone
-from houses.functions import generate_weekly_playlist_video
+from houses.functions import generate_weekly_playlist_video, generate_weekly_playlist_video_shorts
 from houses.models import WeeklyPlaylist
+
+VIDEO_FORMAT_STANDARD = "standard"
+VIDEO_FORMAT_SHORTS = "shorts"
 
 
 class Command(BaseCommand):
@@ -39,6 +42,16 @@ class Command(BaseCommand):
             action="store_true",
             help="Bypass idempotency guards and re-render/re-upload/re-insert the intro video",
         )
+        parser.add_argument(
+            "--format",
+            choices=[VIDEO_FORMAT_STANDARD, VIDEO_FORMAT_SHORTS],
+            default=VIDEO_FORMAT_STANDARD,
+            dest="video_format",
+            help=(
+                "Output format: 'standard' for 1920x1080 long-form, "
+                "'shorts' for 1080x1920 9:16 ≤60s YouTube Shorts (no narration)"
+            ),
+        )
 
     def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003, C901, PLR0911, PLR0912, PLR0915
         """Generate and save playlist introduction video."""
@@ -47,6 +60,7 @@ class Command(BaseCommand):
         secrets_file = Path(options["secrets_file"])
         skip_update_playlist = options["skip_update_playlist"]
         force = options["force"]
+        video_format = options["video_format"]
 
         try:
             playlist = WeeklyPlaylist.objects.get(id=playlist_id)
@@ -56,6 +70,16 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Generating video for playlist: week of {playlist.date.strftime('%Y-%m-%d')}")
         self.stdout.write(f"Playlist URL: {playlist.youtube_playlist_url}")
+
+        if video_format == VIDEO_FORMAT_SHORTS:
+            self.stdout.write("Format: shorts (9:16, ≤60s, no narration)")
+            shorts_filepath = generate_weekly_playlist_video_shorts(playlist)
+            self.stdout.write(self.style.SUCCESS("\n=== Shorts Video Generated ===\n"))
+            self.stdout.write(f"Video saved to: {shorts_filepath}")
+            self.stdout.write(
+                "Upload manually to YouTube Shorts — the playlist intro upload flow is for long-form videos."
+            )
+            return
 
         # Idempotency branches — only relevant when we would otherwise upload/insert.
         if not skip_update_playlist and not force:

--- a/malcom/houses/tests/test_generate_performer_sample_command.py
+++ b/malcom/houses/tests/test_generate_performer_sample_command.py
@@ -1,0 +1,229 @@
+"""Tests for the generate_performer_sample management command and download helper."""
+
+from __future__ import annotations
+
+from datetime import date
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from django.core.management import call_command
+from django.test import TestCase
+from performers.models import Performer, PerformerSong
+
+from houses.functions import download_performer_song_audio
+from houses.models import MonthlyPlaylist, MonthlyPlaylistEntry, WeeklyPlaylist, WeeklyPlaylistEntry
+
+
+def _make_performer(name: str = "TestBand") -> Performer:
+    performer = Performer(name=name, name_kana=name, name_romaji=name)
+    performer._skip_image_fetch = True  # noqa: SLF001
+    performer.save()
+    return performer
+
+
+def _make_song(
+    performer: Performer,
+    title: str = "Test Song",
+    video_id: str = "abc123",
+    youtube_url: str = "",
+) -> PerformerSong:
+    return PerformerSong.objects.create(
+        performer=performer,
+        title=title,
+        youtube_video_id=video_id,
+        youtube_url=youtube_url or f"https://www.youtube.com/watch?v={video_id}",
+        youtube_view_count=1000,
+        youtube_duration_seconds=200,
+    )
+
+
+class TestDownloadPerformerSongAudio(TestCase):
+    def setUp(self) -> None:
+        self.performer = _make_performer()
+        self.song_with_url = _make_song(self.performer, video_id="vidABC")
+        self.song_without_url = PerformerSong.objects.create(
+            performer=self.performer,
+            title="No URL Song",
+            youtube_url="",
+        )
+
+    def test_returns_none_when_no_youtube_url(self) -> None:
+        result = download_performer_song_audio(self.song_without_url)
+        self.assertIsNone(result)
+
+    def test_returns_cached_path_when_file_exists_and_not_forced(self) -> None:
+        with patch("houses.functions.Path.exists", return_value=True):
+            # Patch at the sample dir / song_id.mp3 level
+            result = download_performer_song_audio(self.song_with_url, force=False)
+        # When file exists, should return the path without calling yt_dlp
+        # (yt_dlp would be called if it proceeded past the cache check)
+        self.assertIsNotNone(result)
+
+    def test_calls_yt_dlp_when_file_missing(self) -> None:
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("houses.functions.Path.exists", return_value=False),
+            patch("yt_dlp.YoutubeDL", return_value=mock_ydl) as mock_ydl_cls,
+        ):
+            download_performer_song_audio(self.song_with_url)
+
+        mock_ydl_cls.assert_called_once()
+        mock_ydl.download.assert_called_once_with([self.song_with_url.youtube_url])
+
+    def test_returns_none_on_download_failure(self) -> None:
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.download.side_effect = Exception("network error")
+
+        with (
+            patch("houses.functions.Path.exists", return_value=False),
+            patch("yt_dlp.YoutubeDL", return_value=mock_ydl),
+        ):
+            result = download_performer_song_audio(self.song_with_url)
+
+        self.assertIsNone(result)
+
+    def test_force_flag_skips_cache_check(self) -> None:
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+
+        with (
+            # File "exists" but force=True should still call download
+            patch("houses.functions.Path.exists", return_value=True),
+            patch("yt_dlp.YoutubeDL", return_value=mock_ydl) as mock_ydl_cls,
+        ):
+            download_performer_song_audio(self.song_with_url, force=True)
+
+        mock_ydl_cls.assert_called_once()
+
+
+class TestGeneratePerformerSampleCommand(TestCase):
+    def setUp(self) -> None:
+        self.performer1 = _make_performer("BandAlpha")
+        self.performer2 = _make_performer("BandBeta")
+        self.song1 = _make_song(self.performer1, video_id="vid001")
+        self.song2 = _make_song(self.performer2, video_id="vid002")
+        self.song_no_url = PerformerSong.objects.create(
+            performer=self.performer1,
+            title="Silent Track",
+            youtube_url="",
+        )
+
+        self.weekly_playlist = WeeklyPlaylist.objects.create(
+            date=date(2026, 3, 30),
+            youtube_playlist_id="PLweek1",
+            youtube_playlist_url="https://www.youtube.com/playlist?list=PLweek1",
+        )
+        WeeklyPlaylistEntry.objects.create(playlist=self.weekly_playlist, song=self.song1, position=1)
+        WeeklyPlaylistEntry.objects.create(playlist=self.weekly_playlist, song=self.song2, position=2)
+
+        self.monthly_playlist = MonthlyPlaylist.objects.create(
+            date=date(2026, 3, 1),
+            youtube_playlist_id="PLmonth1",
+            youtube_playlist_url="https://www.youtube.com/playlist?list=PLmonth1",
+        )
+        MonthlyPlaylistEntry.objects.create(playlist=self.monthly_playlist, song=self.song1, position=1)
+
+    def _patch_download(self, return_path: Path | None = None) -> MagicMock:
+        return patch(
+            "houses.management.commands.generate_performer_sample.download_performer_song_audio",
+            return_value=return_path,
+        )
+
+    def test_weekly_playlist_downloads_all_songs(self) -> None:
+        fake_path = Path("/tmp/fake_audio.mp3")  # noqa: S108
+        out = StringIO()
+        with (
+            self._patch_download(return_path=fake_path) as mock_dl,
+            patch("houses.management.commands.generate_performer_sample.Path.exists", return_value=False),
+        ):
+            call_command(
+                "generate_performer_sample",
+                f"--weekly-playlist-id={self.weekly_playlist.id}",
+                stdout=out,
+            )
+
+        self.assertEqual(mock_dl.call_count, 2)
+        called_songs = {call.args[0].id for call in mock_dl.call_args_list}
+        self.assertIn(self.song1.id, called_songs)
+        self.assertIn(self.song2.id, called_songs)
+
+    def test_monthly_playlist_downloads_songs(self) -> None:
+        fake_path = Path("/tmp/fake_audio.mp3")  # noqa: S108
+        out = StringIO()
+        with (
+            self._patch_download(return_path=fake_path) as mock_dl,
+            patch("houses.management.commands.generate_performer_sample.Path.exists", return_value=False),
+        ):
+            call_command(
+                "generate_performer_sample",
+                f"--monthly-playlist-id={self.monthly_playlist.id}",
+                stdout=out,
+            )
+
+        self.assertEqual(mock_dl.call_count, 1)
+        self.assertEqual(mock_dl.call_args.args[0].id, self.song1.id)
+
+    def test_performer_id_downloads_songs_for_that_performer(self) -> None:
+        fake_path = Path("/tmp/fake_audio.mp3")  # noqa: S108
+        out = StringIO()
+        with (
+            self._patch_download(return_path=fake_path) as mock_dl,
+            patch("houses.management.commands.generate_performer_sample.Path.exists", return_value=False),
+        ):
+            call_command(
+                "generate_performer_sample",
+                f"--performer-id={self.performer1.id}",
+                stdout=out,
+            )
+
+        # performer1 has song1 with URL, song_no_url has no URL so should be skipped before dl call
+        self.assertEqual(mock_dl.call_count, 1)
+        self.assertEqual(mock_dl.call_args.args[0].id, self.song1.id)
+
+    def test_missing_weekly_playlist_id_writes_error(self) -> None:
+        err = StringIO()
+        call_command(
+            "generate_performer_sample",
+            "--weekly-playlist-id=99999",
+            stderr=err,
+        )
+        self.assertIn("not found", err.getvalue())
+
+    def test_missing_monthly_playlist_id_writes_error(self) -> None:
+        err = StringIO()
+        call_command(
+            "generate_performer_sample",
+            "--monthly-playlist-id=99999",
+            stderr=err,
+        )
+        self.assertIn("not found", err.getvalue())
+
+    def test_missing_performer_id_writes_error(self) -> None:
+        err = StringIO()
+        call_command(
+            "generate_performer_sample",
+            "--performer-id=99999",
+            stderr=err,
+        )
+        self.assertIn("not found", err.getvalue())
+
+    def test_failed_download_counted_in_output(self) -> None:
+        out = StringIO()
+        with (
+            self._patch_download(return_path=None),
+            patch("houses.management.commands.generate_performer_sample.Path.exists", return_value=False),
+        ):
+            call_command(
+                "generate_performer_sample",
+                f"--weekly-playlist-id={self.weekly_playlist.id}",
+                stdout=out,
+            )
+
+        self.assertIn("failed: 2", out.getvalue())

--- a/malcom/houses/tests/test_generate_performer_sample_command.py
+++ b/malcom/houses/tests/test_generate_performer_sample_command.py
@@ -170,7 +170,7 @@ class TestGeneratePerformerSampleCommand(TestCase):
         self.assertEqual(mock_dl.call_count, 1)
         self.assertEqual(mock_dl.call_args.args[0].id, self.song1.id)
 
-    def test_performer_id_downloads_songs_for_that_performer(self) -> None:
+    def test_performer_id_filters_to_single_performer_in_weekly_playlist(self) -> None:
         fake_path = Path("/tmp/fake_audio.mp3")  # noqa: S108
         out = StringIO()
         with (
@@ -179,13 +179,36 @@ class TestGeneratePerformerSampleCommand(TestCase):
         ):
             call_command(
                 "generate_performer_sample",
+                f"--weekly-playlist-id={self.weekly_playlist.id}",
                 f"--performer-id={self.performer1.id}",
                 stdout=out,
             )
 
-        # performer1 has song1 with URL, song_no_url has no URL so should be skipped before dl call
+        # Only performer1's song (song1) should be downloaded; performer2 (song2) is excluded
         self.assertEqual(mock_dl.call_count, 1)
         self.assertEqual(mock_dl.call_args.args[0].id, self.song1.id)
+
+    def test_performer_id_filters_to_single_performer_in_monthly_playlist(self) -> None:
+        # Add performer2's song to the monthly playlist for this test
+        from houses.models import MonthlyPlaylistEntry  # noqa: PLC0415
+
+        MonthlyPlaylistEntry.objects.create(playlist=self.monthly_playlist, song=self.song2, position=2)
+
+        fake_path = Path("/tmp/fake_audio.mp3")  # noqa: S108
+        out = StringIO()
+        with (
+            self._patch_download(return_path=fake_path) as mock_dl,
+            patch("houses.management.commands.generate_performer_sample.Path.exists", return_value=False),
+        ):
+            call_command(
+                "generate_performer_sample",
+                f"--monthly-playlist-id={self.monthly_playlist.id}",
+                f"--performer-id={self.performer2.id}",
+                stdout=out,
+            )
+
+        self.assertEqual(mock_dl.call_count, 1)
+        self.assertEqual(mock_dl.call_args.args[0].id, self.song2.id)
 
     def test_missing_weekly_playlist_id_writes_error(self) -> None:
         err = StringIO()
@@ -205,14 +228,16 @@ class TestGeneratePerformerSampleCommand(TestCase):
         )
         self.assertIn("not found", err.getvalue())
 
-    def test_missing_performer_id_writes_error(self) -> None:
+    def test_performer_id_not_in_playlist_writes_error(self) -> None:
+        performer3 = _make_performer("BandGamma")
         err = StringIO()
         call_command(
             "generate_performer_sample",
-            "--performer-id=99999",
+            f"--weekly-playlist-id={self.weekly_playlist.id}",
+            f"--performer-id={performer3.id}",
             stderr=err,
         )
-        self.assertIn("not found", err.getvalue())
+        self.assertIn("No songs found", err.getvalue())
 
     def test_failed_download_counted_in_output(self) -> None:
         out = StringIO()

--- a/malcom/houses/tests/test_generate_weekly_playlist_video_command.py
+++ b/malcom/houses/tests/test_generate_weekly_playlist_video_command.py
@@ -201,6 +201,35 @@ class TestGenerateWeeklyPlaylistVideoCommand(TestCase):
 
     @patch("houses.management.commands.generate_weekly_playlist_video.insert_video_at_position")
     @patch("houses.management.commands.generate_weekly_playlist_video.upload_video_to_youtube")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video_shorts")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video")
+    def test_format_shorts_invokes_shorts_generator_and_skips_upload(
+        self,
+        mock_standard_gen: MagicMock,
+        mock_shorts_gen: MagicMock,
+        mock_upload: MagicMock,
+        mock_insert: MagicMock,
+    ) -> None:
+        """AC: --format shorts routes to the shorts generator and never uploads/inserts."""
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as tmp_video:
+            mock_shorts_gen.return_value = Path(tmp_video.name)
+            call_command(
+                "generate_weekly_playlist_video",
+                str(self.playlist.id),
+                format="shorts",
+            )
+
+        mock_shorts_gen.assert_called_once_with(self.playlist)
+        mock_standard_gen.assert_not_called()
+        mock_upload.assert_not_called()
+        mock_insert.assert_not_called()
+
+        self.playlist.refresh_from_db()
+        self.assertEqual(self.playlist.intro_youtube_video_id, "")
+        self.assertIsNone(self.playlist.intro_video_inserted_datetime)
+
+    @patch("houses.management.commands.generate_weekly_playlist_video.insert_video_at_position")
+    @patch("houses.management.commands.generate_weekly_playlist_video.upload_video_to_youtube")
     @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video")
     def test_intro_video_id_persisted_before_insert(
         self, mock_gen: MagicMock, mock_upload: MagicMock, mock_insert: MagicMock

--- a/malcom/houses/tests/test_video_slide_renderers.py
+++ b/malcom/houses/tests/test_video_slide_renderers.py
@@ -16,12 +16,16 @@ from django.test import TestCase
 from PIL import Image
 
 from houses.functions import (
+    render_shorts_closing_slide,
+    render_shorts_intro_slide,
+    render_shorts_performer_slide,
     render_video_closing_slide,
     render_video_intro_slide,
     render_video_performer_slide,
 )
 
 VIDEO_SIZE = (1920, 1080)
+SHORTS_SIZE = (1080, 1920)
 
 
 class TestRenderVideoIntroSlide(TestCase):
@@ -118,6 +122,63 @@ class TestRenderVideoClosingSlide(TestCase):
             channel_url="https://www.youtube.com/@hakkoakkei",
         )
         self.assertEqual(img.size, VIDEO_SIZE)
+
+
+class TestRenderShortsIntroSlide(TestCase):
+    def test_shorts_intro_with_full_lineup(self) -> None:
+        lineup = [
+            (1, "残響のリフレイン", True),
+            (2, "OGRE YOU ASSHOLE", False),
+            (3, "tricot", False),
+            (4, "Mass of the Fermenting Dregs", False),
+            (5, "envy", True),
+            (6, "toe", False),
+        ]
+        img = render_shorts_intro_slide(title_label="Week of 2026-04-13", lineup=lineup)
+        self.assertIsInstance(img, Image.Image)
+        self.assertEqual(img.size, SHORTS_SIZE)
+
+    def test_shorts_intro_with_empty_lineup(self) -> None:
+        img = render_shorts_intro_slide(title_label="April 2026", lineup=[])
+        self.assertEqual(img.size, SHORTS_SIZE)
+
+    def test_shorts_intro_caps_long_lineup(self) -> None:
+        oversized_lineup = [(i, f"Performer {i}", False) for i in range(1, 30)]
+        img = render_shorts_intro_slide(title_label="Big Month", lineup=oversized_lineup)
+        self.assertEqual(img.size, SHORTS_SIZE)
+
+
+class TestRenderShortsPerformerSlide(TestCase):
+    def test_shorts_performer_with_all_fields(self) -> None:
+        img = render_shorts_performer_slide(
+            position=3,
+            performer=_stub_performer(),
+            song_title="Crimson Tide",
+            venue_name="下北沢SHELTER",
+            performance_date=date(2026, 4, 15),
+            artist_url="https://example.com/artist",
+        )
+        self.assertEqual(img.size, SHORTS_SIZE)
+
+    def test_shorts_performer_with_no_qr_target(self) -> None:
+        img = render_shorts_performer_slide(
+            position=1,
+            performer=_stub_performer(),
+            song_title="",
+            venue_name=None,
+            performance_date=None,
+            artist_url=None,
+        )
+        self.assertEqual(img.size, SHORTS_SIZE)
+
+
+class TestRenderShortsClosingSlide(TestCase):
+    def test_shorts_closing_renders(self) -> None:
+        img = render_shorts_closing_slide(
+            closing_text="See you next week",
+            channel_url="https://www.youtube.com/@hakkoakkei",
+        )
+        self.assertEqual(img.size, SHORTS_SIZE)
 
 
 class TestBrandWashCanvasNoGrain(TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "qrcode>=8.2",
     "requests>=2.32.4",
     "whitenoise<7.0",
+    "yt-dlp>=2026.3.17",
     "zappa<0.60",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -719,6 +719,7 @@ dependencies = [
     { name = "qrcode" },
     { name = "requests" },
     { name = "whitenoise" },
+    { name = "yt-dlp" },
     { name = "zappa" },
 ]
 
@@ -753,6 +754,7 @@ requires-dist = [
     { name = "qrcode", specifier = ">=8.2" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "whitenoise", specifier = "<7.0" },
+    { name = "yt-dlp", specifier = ">=2026.3.17" },
     { name = "zappa", specifier = "<0.60" },
 ]
 
@@ -1647,6 +1649,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/74/8b74bae38ed7fe6793d0c15a0c8207bbb819cf287788459e5ed230996cdd/yarl-1.22.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff86011bd159a9d2dfc89c34cfd8aff12875980e3bd6a39ff097887520e60249", size = 93715, upload-time = "2025-10-06T14:11:11.739Z" },
     { url = "https://files.pythonhosted.org/packages/69/66/991858aa4b5892d57aef7ee1ba6b4d01ec3b7eb3060795d34090a3ca3278/yarl-1.22.0-cp313-cp313t-win_arm64.whl", hash = "sha256:7861058d0582b847bc4e3a4a4c46828a410bca738673f35a29ba3ca5db0b473b", size = 83857, upload-time = "2025-10-06T14:11:13.586Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/34/7c6b4e3f89cb6416d2cd7ab6dab141a1df97ab0fb22d15816db2c92148c9/yt_dlp-2026.3.17.tar.gz", hash = "sha256:ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9", size = 3119221, upload-time = "2026-03-17T23:43:00.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/13/5093bcb954878e50f7217fd2ab94282b53934022e4e4a03265582da83bf5/yt_dlp-2026.3.17-py3-none-any.whl", hash = "sha256:32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8", size = 3315134, upload-time = "2026-03-17T23:42:57.863Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `--format shorts` to `generate_weekly_playlist_video` and `generate_playlist_video` to produce vertical 1080×1920 YouTube Shorts (≤60s).
- Three new vertical renderers in `houses/functions.py` (`render_shorts_intro_slide`, `render_shorts_performer_slide`, `render_shorts_closing_slide`) reuse the shared brand palette/typography in `commons/design.py` plus a new `VIDEO_SHORTS = (1080, 1920)` canvas constant.
- New coordinator `_generate_playlist_video_shorts` caps performer slides so 3s intro + 4s/performer + 3s closing always fits the 60s YouTube Shorts limit. Background music only — no narration TTS to keep the budget deterministic.

Closes #72

## Acceptance criteria

- [x] `--format shorts` flag produces a 9:16 vertical video ≤60s
- [x] Output resolution is 1080×1920 (standard Shorts resolution)
- [x] Visual style follows the established HAKKO-AKKEI design (display-serif, vermillion accents, paper-black wash, corner wordmark)
- [x] Rendered with H.264 + AAC at 30fps (YouTube Shorts upload-compatible)
- [x] Unit tests cover the new render paths and command routing

## Test plan

- [x] `uv run poe test` — 383 tests pass
- [x] `uv run ruff check malcom/houses/functions.py malcom/commons/design.py …` — no new lint errors
- [x] `uv run python manage.py generate_weekly_playlist_video --help` — `--format {standard,shorts}` listed
- [ ] Manual: run `generate_weekly_playlist_video <id> --format shorts` against a real playlist and verify ffprobe shows 1080×1920 @ ≤60s