### PR TITLE
fix(performer-validation): buffer social links on unsaved performers before validation

### DIFF
--- a/malcom/houses/crawlers/crawler.py
+++ b/malcom/houses/crawlers/crawler.py
@@ -515,6 +515,21 @@ class LiveHouseWebsiteCrawler(ABC):  # noqa: B024
                     )
                     if created:
                         logger.info(f"✅ Created performer in database: {existing_performer.name}")
+                        # Flush buffered social links now that the performer has a PK
+                        pending = getattr(performer, "_pending_social_links", [])
+                        for link_info in pending:
+                            _, link_created = PerformerSocialLink.objects.get_or_create(
+                                performer=existing_performer,
+                                platform=link_info["platform"],
+                                defaults={
+                                    "platform_id": link_info.get("platform_id", ""),
+                                    "url": link_info.get("url", ""),
+                                },
+                            )
+                            if link_created:
+                                logger.debug(
+                                    f"Flushed pending {link_info['platform']} link for {existing_performer.name}"
+                                )
                     else:
                         logger.info(
                             f"ℹ️ Using existing performer with same romaji: {existing_performer.name} "
@@ -1308,13 +1323,23 @@ class LiveHouseWebsiteCrawler(ABC):  # noqa: B024
         Note: YouTube links are skipped here as they are populated more accurately
         from youtube_search.search_and_create_performer_songs() which extracts
         the channel ID directly from YouTube's data.
-        """
-        try:
-            for link_info in social_links:
-                # Skip YouTube links - these are handled by youtube_search module
-                if link_info["platform"] == "youtube":
-                    continue
 
+        When the performer has not yet been saved (pk is None), links are buffered
+        in performer._pending_social_links and applied after the DB record is created
+        by _save_and_link_performers.
+        """
+        non_youtube = [link for link in social_links if link.get("platform") != "youtube"]
+
+        if performer.pk is None:
+            # Buffer for post-save application — cannot write FK rows without a PK
+            if not hasattr(performer, "_pending_social_links"):
+                performer._pending_social_links = []
+            performer._pending_social_links.extend(non_youtube)
+            logger.debug(f"Buffered {len(non_youtube)} social links for unsaved performer {performer.name}")
+            return
+
+        try:
+            for link_info in non_youtube:
                 _, created = PerformerSocialLink.objects.get_or_create(
                     performer=performer,
                     platform=link_info["platform"],

--- a/malcom/performers/models.py
+++ b/malcom/performers/models.py
@@ -80,27 +80,33 @@ class Performer(TimestampedModel):
 
     def has_valid_online_presence(self):
         """Check if performer has valid social media or unique website presence."""
+        valid_social_platforms = {
+            "twitter",
+            "instagram",
+            "facebook",
+            "youtube",
+            "bandcamp",
+            "soundcloud",
+            "spotify",
+            "apple_music",
+            "tiktok",
+            "discord",
+            "twitch",
+            "reddit",
+            "linkedin",
+            "vimeo",
+            "github",
+            "patreon",
+            "mastodon",
+        }
+
+        # Check pending social links buffered during pre-save validation
+        for link in getattr(self, "_pending_social_links", []):
+            if link.get("platform", "").lower() in valid_social_platforms and link.get("url"):
+                return True
+
         # Check for social media links (only if performer is saved to database)
         if self.pk and hasattr(self, "social_links") and self.social_links.exists():
-            valid_social_platforms = [
-                "twitter",
-                "instagram",
-                "facebook",
-                "youtube",
-                "bandcamp",
-                "soundcloud",
-                "spotify",
-                "apple_music",
-                "tiktok",
-                "discord",
-                "twitch",
-                "reddit",
-                "linkedin",
-                "vimeo",
-                "github",
-                "patreon",
-                "mastodon",
-            ]
             for link in self.social_links.all():
                 if link.platform.lower() in valid_social_platforms and link.url:
                     return True

--- a/malcom/performers/tests/test_pending_social_links.py
+++ b/malcom/performers/tests/test_pending_social_links.py
@@ -1,0 +1,108 @@
+"""Tests for Option B fix: pending social links buffered on unsaved performers."""
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from houses.crawlers.crawler import LiveHouseWebsiteCrawler
+
+from performers.models import Performer, PerformerSocialLink
+
+
+class _TestCrawler(LiveHouseWebsiteCrawler):
+    def extract_live_house_info(self, html_content: str) -> dict:  # type: ignore[override]
+        return {}
+
+    def extract_performance_schedules(self, html_content: str, live_house: object, source_url: str = "") -> list:  # type: ignore[override]
+        return []
+
+
+class TestHasValidOnlinePresencePending(TestCase):
+    """has_valid_online_presence() should honour _pending_social_links on unsaved performers."""
+
+    def _make_unsaved_performer(self) -> Performer:
+        return Performer(name="Test Band", name_kana="テスト", name_romaji="tesuto")
+
+    def test_no_presence_returns_false(self) -> None:
+        p = self._make_unsaved_performer()
+        self.assertFalse(p.has_valid_online_presence())
+
+    def test_pending_valid_platform_returns_true(self) -> None:
+        p = self._make_unsaved_performer()
+        p._pending_social_links = [
+            {"platform": "instagram", "platform_id": "testband", "url": "https://instagram.com/testband"}
+        ]
+        self.assertTrue(p.has_valid_online_presence())
+
+    def test_pending_youtube_still_counts(self) -> None:
+        p = self._make_unsaved_performer()
+        p._pending_social_links = [
+            {"platform": "youtube", "platform_id": "UCabc", "url": "https://youtube.com/c/testband"}
+        ]
+        self.assertTrue(p.has_valid_online_presence())
+
+    def test_pending_with_empty_url_returns_false(self) -> None:
+        p = self._make_unsaved_performer()
+        p._pending_social_links = [{"platform": "twitter", "platform_id": "", "url": ""}]
+        self.assertFalse(p.has_valid_online_presence())
+
+    def test_pending_with_unknown_platform_returns_false(self) -> None:
+        p = self._make_unsaved_performer()
+        p._pending_social_links = [
+            {"platform": "unknown_platform", "platform_id": "x", "url": "https://unknown.example.com/x"}
+        ]
+        self.assertFalse(p.has_valid_online_presence())
+
+    def test_website_still_validates_without_pending(self) -> None:
+        p = self._make_unsaved_performer()
+        p.website = "https://testband.com"
+        self.assertTrue(p.has_valid_online_presence())
+
+
+class TestUpdatePerformerSocialLinksBuffering(TestCase):
+    """_update_performer_social_links buffers for unsaved performers instead of hitting the DB."""
+
+    def setUp(self) -> None:
+        self.crawler = _TestCrawler.__new__(_TestCrawler)
+        self.crawler.session = MagicMock()
+        self.crawler.timeout = 10
+
+    def _make_unsaved_performer(self) -> Performer:
+        return Performer(name="Test Band", name_kana="テスト", name_romaji="tesuto")
+
+    def _sample_links(self) -> list[dict]:
+        return [
+            {"platform": "instagram", "platform_id": "testband", "url": "https://instagram.com/testband"},
+            {"platform": "youtube", "platform_id": "UCabc", "url": "https://youtube.com/c/testband"},
+        ]
+
+    def test_unsaved_performer_buffers_links(self) -> None:
+        p = self._make_unsaved_performer()
+        self.crawler._update_performer_social_links(p, self._sample_links())
+        # YouTube excluded from buffer; instagram included
+        self.assertTrue(hasattr(p, "_pending_social_links"))
+        platforms = [link["platform"] for link in p._pending_social_links]
+        self.assertIn("instagram", platforms)
+        self.assertNotIn("youtube", platforms)
+
+    def test_unsaved_performer_no_db_write(self) -> None:
+        p = self._make_unsaved_performer()
+        self.crawler._update_performer_social_links(p, self._sample_links())
+        self.assertEqual(PerformerSocialLink.objects.count(), 0)
+
+    def test_pending_links_accumulate_across_calls(self) -> None:
+        p = self._make_unsaved_performer()
+        self.crawler._update_performer_social_links(
+            p, [{"platform": "instagram", "platform_id": "a", "url": "https://instagram.com/a"}]
+        )
+        self.crawler._update_performer_social_links(
+            p, [{"platform": "twitter", "platform_id": "b", "url": "https://twitter.com/b"}]
+        )
+        platforms = {link["platform"] for link in p._pending_social_links}
+        self.assertEqual(platforms, {"instagram", "twitter"})
+
+    def test_saved_performer_writes_to_db(self) -> None:
+        p = Performer.objects.create(name="DB Band", name_kana="テスト", name_romaji="tesuto2")
+        self.crawler._update_performer_social_links(
+            p, [{"platform": "instagram", "platform_id": "dbband", "url": "https://instagram.com/dbband"}]
+        )
+        self.assertEqual(PerformerSocialLink.objects.filter(performer=p).count(), 1)


### PR DESCRIPTION
## Summary

Fixes #77 — implements Option B: store discovered social links as `_pending_social_links` on the unsaved performer instance and update `has_valid_online_presence` to check it.

**Root cause recap:** `_update_performer_social_links` called `get_or_create(performer=performer, ...)` while `performer.pk is None`, which Django silently dropped (FK constraint caught by broad `except`). `has_valid_online_presence` only checked the DB, so it always returned `False` for new performers → every new artist was rejected.

**Changes:**
- `performers/models.py` — `has_valid_online_presence()` checks `_pending_social_links` (a list of `{platform, platform_id, url}` dicts) before querying the DB, so unsaved performers with buffered links pass validation.
- `houses/crawlers/crawler.py` — `_update_performer_social_links()` detects `pk is None` and buffers non-YouTube links into `performer._pending_social_links` instead of hitting the DB.
- `houses/crawlers/crawler.py` — `_save_and_link_performers()` flushes `_pending_social_links` to `PerformerSocialLink` rows immediately after the performer is created.

**Tests:** 10 new unit tests in `performers/tests/test_pending_social_links.py` covering:
- `has_valid_online_presence` with pending links (valid platform, empty URL, unknown platform, website fallback)
- `_update_performer_social_links` buffering vs. direct DB write
- Link accumulation across multiple calls
- Full suite: 407 tests, all pass.

## Test plan
- [x] `manage.py test performers.tests.test_pending_social_links` — 10/10 pass
- [x] `manage.py test` full suite — 407/407 pass
- [x] `ruff check` — clean