### PR TITLE
feat(image-coverage): pre-post health check for performer/event scrapers

### DIFF
--- a/malcom/commons/image_coverage.py
+++ b/malcom/commons/image_coverage.py
@@ -1,0 +1,137 @@
+"""Image coverage metrics for performer / event scraper health.
+
+Surface silent scraper failures (TheAudioDB/MusicBrainz for performer art,
+crawler-driven event flyers for ``PerformanceSchedule.event_image``) by
+counting how many performers in the upcoming week have artwork and how
+many schedules carry a flyer. Used by ``post_weekly_playlist`` for a
+pre-post summary and by ``check_image_coverage`` as a stand-alone health
+check that can run from cron.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from performers.models import Performer
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PERFORMER_COVERAGE_THRESHOLD = 0.7
+
+PERFORMER_IMAGE_FIELDS: tuple[str, ...] = (
+    "performer_image",
+    "logo_image",
+    "fanart_image",
+    "banner_image",
+)
+
+
+@dataclass(frozen=True)
+class ImageCoverageReport:
+    """Snapshot of performer / event-image coverage for a target week."""
+
+    week_start: date
+    performer_total: int
+    performers_with_image: int
+    performers_without_image: list[str] = field(default_factory=list)
+    schedule_total: int = 0
+    schedules_with_event_image: int = 0
+    threshold: float = DEFAULT_PERFORMER_COVERAGE_THRESHOLD
+
+    @property
+    def performer_coverage_ratio(self) -> float:
+        if not self.performer_total:
+            return 1.0
+        return self.performers_with_image / self.performer_total
+
+    @property
+    def schedule_coverage_ratio(self) -> float:
+        if not self.schedule_total:
+            return 1.0
+        return self.schedules_with_event_image / self.schedule_total
+
+    @property
+    def below_threshold(self) -> bool:
+        return self.performer_total > 0 and self.performer_coverage_ratio < self.threshold
+
+    def to_log_payload(self, *, context: str) -> dict:
+        return {
+            "event": "image_coverage_summary",
+            "context": context,
+            "week_start": self.week_start.isoformat(),
+            "performer_total": self.performer_total,
+            "performers_with_image": self.performers_with_image,
+            "performers_without_image_count": len(self.performers_without_image),
+            "performer_coverage_ratio": round(self.performer_coverage_ratio, 3),
+            "schedule_total": self.schedule_total,
+            "schedules_with_event_image": self.schedules_with_event_image,
+            "schedule_coverage_ratio": round(self.schedule_coverage_ratio, 3),
+            "threshold": self.threshold,
+            "below_threshold": self.below_threshold,
+        }
+
+
+def performer_has_image(performer: Performer) -> bool:
+    """Return True if the performer has at least one image field populated."""
+    return any(getattr(performer, field_name) for field_name in PERFORMER_IMAGE_FIELDS)
+
+
+def build_image_coverage_report(
+    performers: Iterable[Performer],
+    week_start: date,
+    *,
+    threshold: float = DEFAULT_PERFORMER_COVERAGE_THRESHOLD,
+) -> ImageCoverageReport:
+    """Count performer and schedule image coverage for the target week.
+
+    Schedules are restricted to those between ``week_start`` and
+    ``week_start + 7 days`` that include at least one of the supplied
+    performers, matching what ``post_weekly_playlist`` actually surfaces.
+    """
+    from houses.models import PerformanceSchedule  # noqa: PLC0415 — avoid app-ready import cycle
+
+    performer_list = list(performers)
+    performer_total = len(performer_list)
+    with_image = [p for p in performer_list if performer_has_image(p)]
+    without_image: list[str] = [str(p.name) for p in performer_list if not performer_has_image(p)]
+
+    schedule_total = 0
+    schedules_with_event_image = 0
+    if performer_list:
+        week_end = week_start + timedelta(days=7)
+        schedule_qs = PerformanceSchedule.objects.filter(
+            performers__in=performer_list,
+            performance_date__gte=week_start,
+            performance_date__lt=week_end,
+        ).distinct()
+        schedule_total = schedule_qs.count()
+        schedules_with_event_image = schedule_qs.exclude(event_image="").exclude(event_image__isnull=True).count()
+
+    return ImageCoverageReport(
+        week_start=week_start,
+        performer_total=performer_total,
+        performers_with_image=len(with_image),
+        performers_without_image=without_image,
+        schedule_total=schedule_total,
+        schedules_with_event_image=schedules_with_event_image,
+        threshold=threshold,
+    )
+
+
+def log_image_coverage_report(report: ImageCoverageReport, *, context: str) -> None:
+    """Emit a structured INFO (or WARNING when below threshold) log line."""
+    payload = report.to_log_payload(context=context)
+    if report.below_threshold:
+        logger.warning(
+            "image_coverage_below_threshold payload=%s missing=%s",
+            payload,
+            report.performers_without_image,
+        )
+    else:
+        logger.info("image_coverage_summary payload=%s", payload)

--- a/malcom/commons/tests/test_image_coverage.py
+++ b/malcom/commons/tests/test_image_coverage.py
@@ -1,0 +1,190 @@
+"""Tests for the commons.image_coverage module."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from houses.models import LiveHouse, LiveHouseWebsite, PerformanceSchedule
+from performers.models import Performer
+
+from commons.image_coverage import (
+    DEFAULT_PERFORMER_COVERAGE_THRESHOLD,
+    ImageCoverageReport,
+    build_image_coverage_report,
+    log_image_coverage_report,
+    performer_has_image,
+)
+
+
+def _make_performer(name: str, *, with_image: bool = False) -> Performer:
+    performer = Performer(name=name, name_kana=name, name_romaji=name)
+    performer._skip_image_fetch = True  # noqa: SLF001
+    performer.save()
+    if with_image:
+        performer.performer_image.save(f"{name}.jpg", ContentFile(b"fake"), save=True)
+    return performer
+
+
+def _make_schedule(
+    live_house: LiveHouse,
+    performance_date: date,
+    performer: Performer,
+    *,
+    with_image: bool = False,
+) -> PerformanceSchedule:
+    schedule = PerformanceSchedule.objects.create(
+        live_house=live_house,
+        performance_name="Test Show",
+        performance_date=performance_date,
+    )
+    schedule.performers.add(performer)
+    if with_image:
+        schedule.event_image.save(f"{performer.name}-flyer.jpg", ContentFile(b"flyer"), save=True)
+    return schedule
+
+
+class PerformerHasImageTests(TestCase):
+    def test_returns_true_when_any_image_set(self) -> None:
+        performer = _make_performer("WithImage", with_image=True)
+        self.assertTrue(performer_has_image(performer))
+
+    def test_returns_false_when_all_images_blank(self) -> None:
+        performer = _make_performer("NoImage")
+        self.assertFalse(performer_has_image(performer))
+
+
+class BuildImageCoverageReportTests(TestCase):
+    def setUp(self) -> None:
+        self.week_start = date(2026, 6, 1)
+        self.website = LiveHouseWebsite.objects.create(url="https://example.com/")
+        self.live_house = LiveHouse.objects.create(
+            website=self.website,
+            name="Test Venue",
+            name_kana="テスト",
+            name_romaji="Test",
+            address="addr",
+            capacity=100,
+            opened_date=date(2000, 1, 1),
+        )
+
+    def test_empty_performer_list_returns_full_coverage_ratio(self) -> None:
+        report = build_image_coverage_report([], self.week_start)
+        self.assertEqual(report.performer_total, 0)
+        self.assertEqual(report.performer_coverage_ratio, 1.0)
+        self.assertFalse(report.below_threshold)
+        self.assertEqual(report.schedule_total, 0)
+        self.assertEqual(report.schedule_coverage_ratio, 1.0)
+
+    def test_counts_performers_with_and_without_images(self) -> None:
+        with_image = _make_performer("HasArt", with_image=True)
+        without_image = _make_performer("NoArt")
+
+        report = build_image_coverage_report([with_image, without_image], self.week_start)
+
+        self.assertEqual(report.performer_total, 2)
+        self.assertEqual(report.performers_with_image, 1)
+        self.assertEqual(report.performers_without_image, ["NoArt"])
+        self.assertAlmostEqual(report.performer_coverage_ratio, 0.5)
+
+    def test_below_threshold_triggers_when_ratio_under_default(self) -> None:
+        performers = [_make_performer(f"NoArt{i}") for i in range(8)]
+        performers += [_make_performer(f"HasArt{i}", with_image=True) for i in range(2)]
+
+        report = build_image_coverage_report(performers, self.week_start)
+
+        self.assertLess(report.performer_coverage_ratio, DEFAULT_PERFORMER_COVERAGE_THRESHOLD)
+        self.assertTrue(report.below_threshold)
+
+    def test_above_threshold_does_not_trigger(self) -> None:
+        performers = [_make_performer(f"HasArt{i}", with_image=True) for i in range(8)]
+        performers += [_make_performer(f"NoArt{i}") for i in range(2)]
+
+        report = build_image_coverage_report(performers, self.week_start)
+
+        self.assertGreaterEqual(report.performer_coverage_ratio, DEFAULT_PERFORMER_COVERAGE_THRESHOLD)
+        self.assertFalse(report.below_threshold)
+
+    def test_counts_schedules_within_target_week(self) -> None:
+        performer = _make_performer("InWeek", with_image=True)
+        _make_schedule(self.live_house, date(2026, 6, 3), performer, with_image=True)
+        _make_schedule(self.live_house, date(2026, 6, 6), performer)
+        # Outside the target week — must not be counted.
+        _make_schedule(self.live_house, date(2026, 6, 12), performer, with_image=True)
+
+        report = build_image_coverage_report([performer], self.week_start)
+
+        self.assertEqual(report.schedule_total, 2)
+        self.assertEqual(report.schedules_with_event_image, 1)
+        self.assertAlmostEqual(report.schedule_coverage_ratio, 0.5)
+
+    def test_custom_threshold_overrides_default(self) -> None:
+        performer = _make_performer("HasArt", with_image=True)
+
+        report = build_image_coverage_report([performer], self.week_start, threshold=1.0)
+
+        self.assertEqual(report.threshold, 1.0)
+        self.assertFalse(report.below_threshold)
+
+
+class LogImageCoverageReportTests(TestCase):
+    def test_warning_logged_when_below_threshold(self) -> None:
+        report = ImageCoverageReport(
+            week_start=date(2026, 6, 1),
+            performer_total=10,
+            performers_with_image=3,
+            performers_without_image=[f"Missing{i}" for i in range(7)],
+            schedule_total=4,
+            schedules_with_event_image=1,
+            threshold=0.7,
+        )
+
+        with self.assertLogs("commons.image_coverage", level="WARNING") as captured:
+            log_image_coverage_report(report, context="unit-test")
+
+        joined = "\n".join(captured.output)
+        self.assertIn("image_coverage_below_threshold", joined)
+        self.assertIn("Missing0", joined)
+
+    def test_info_logged_when_at_or_above_threshold(self) -> None:
+        report = ImageCoverageReport(
+            week_start=date(2026, 6, 1),
+            performer_total=10,
+            performers_with_image=9,
+            performers_without_image=["Missing"],
+            schedule_total=4,
+            schedules_with_event_image=4,
+            threshold=0.7,
+        )
+
+        with self.assertLogs("commons.image_coverage", level="INFO") as captured:
+            log_image_coverage_report(report, context="unit-test")
+
+        joined = "\n".join(captured.output)
+        self.assertIn("image_coverage_summary", joined)
+        self.assertNotIn("image_coverage_below_threshold", joined)
+
+
+class ImageCoverageReportLogPayloadTests(TestCase):
+    def test_payload_includes_threshold_and_ratio(self) -> None:
+        report = ImageCoverageReport(
+            week_start=date(2026, 6, 1),
+            performer_total=4,
+            performers_with_image=3,
+            performers_without_image=["Missing"],
+            schedule_total=2,
+            schedules_with_event_image=1,
+            threshold=0.7,
+        )
+
+        payload = report.to_log_payload(context="ctx")
+
+        self.assertEqual(payload["context"], "ctx")
+        self.assertEqual(payload["performer_total"], 4)
+        self.assertEqual(payload["performers_with_image"], 3)
+        self.assertEqual(payload["performers_without_image_count"], 1)
+        self.assertEqual(payload["performer_coverage_ratio"], 0.75)
+        self.assertEqual(payload["schedule_coverage_ratio"], 0.5)
+        self.assertEqual(payload["threshold"], 0.7)
+        self.assertFalse(payload["below_threshold"])

--- a/malcom/houses/management/commands/post_weekly_playlist.py
+++ b/malcom/houses/management/commands/post_weekly_playlist.py
@@ -20,6 +20,7 @@ import io
 import logging
 from datetime import timedelta
 
+from commons.image_coverage import build_image_coverage_report, log_image_coverage_report
 from commons.instagram_images import (
     INSTAGRAM_HASHTAGS,
     _resize_to_square,
@@ -175,6 +176,27 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Playlist: {playlist.id} — {week_label}")
         self.stdout.write(f"Entries: {len(entries)}")
+
+        # Image coverage pre-post check — surfaces silent scraper failures.
+        coverage_performers = [e.song.performer for e in all_entries]
+        coverage_report = build_image_coverage_report(coverage_performers, week_start)
+        log_image_coverage_report(coverage_report, context="post_weekly_playlist")
+        self.stdout.write(
+            f"Image coverage: {coverage_report.performers_with_image}/{coverage_report.performer_total} "
+            f"performers have artwork ({coverage_report.performer_coverage_ratio:.0%}); "
+            f"{coverage_report.schedules_with_event_image}/{coverage_report.schedule_total} "
+            f"schedules have event_image ({coverage_report.schedule_coverage_ratio:.0%})."
+        )
+        if coverage_report.performers_without_image:
+            self.stdout.write(f"Performers without artwork: {', '.join(coverage_report.performers_without_image)}")
+        if coverage_report.below_threshold:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"WARNING: performer image coverage {coverage_report.performer_coverage_ratio:.0%} "
+                    f"is below threshold {coverage_report.threshold:.0%}; "
+                    "post will fall back to default backgrounds for missing performers."
+                )
+            )
 
         # --- Build caption ---
         performer_song_pairs = [(e.song.performer, e.song) for e in entries]

--- a/malcom/houses/tests/test_post_weekly_playlist.py
+++ b/malcom/houses/tests/test_post_weekly_playlist.py
@@ -142,6 +142,22 @@ class TestPostWeeklyPlaylistCommand(TestCase):
         self.playlist.refresh_from_db()
         self.assertEqual(self.playlist.instagram_post_id, "new_post_id")
 
+    def test_dry_run_emits_image_coverage_summary(self) -> None:
+        out = StringIO()
+        with self.assertLogs("commons.image_coverage", level="INFO") as cm:
+            call_command("post_weekly_playlist", "--dry-run", stdout=out)
+        output = out.getvalue()
+        self.assertIn("Image coverage:", output)
+        self.assertTrue(any("image_coverage" in msg for msg in cm.output))
+
+    def test_below_threshold_emits_warning_log(self) -> None:
+        # Default fixture has 1 performer with no image — coverage is 0%, below 70%.
+        out = StringIO()
+        with self.assertLogs("commons.image_coverage", level="WARNING") as cm:
+            call_command("post_weekly_playlist", "--dry-run", stdout=out)
+        self.assertTrue(any("image_coverage_below_threshold" in msg for msg in cm.output))
+        self.assertIn("WARNING", out.getvalue())
+
     def test_instagram_post_id_persisted_immediately_after_post(self) -> None:
         """AC: instagram_post_id is saved immediately after post_carousel returns."""
         handler_mock = MagicMock(return_value="fresh_post_id")

--- a/malcom/performers/management/commands/check_image_coverage.py
+++ b/malcom/performers/management/commands/check_image_coverage.py
@@ -1,0 +1,136 @@
+"""Report performer / event-image coverage and warn when below threshold.
+
+Designed to run from cron so silent scraper failures (TheAudioDB,
+MusicBrainz, event-flyer crawlers) surface before they cause carousel
+posts to fall back to the default background. Exits non-zero with code
+``EXIT_BELOW_THRESHOLD`` when the performer coverage ratio is below the
+configured threshold so cron alerting (mail-on-failure, etc.) fires.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date, datetime, timedelta
+
+from commons.image_coverage import (
+    DEFAULT_PERFORMER_COVERAGE_THRESHOLD,
+    build_image_coverage_report,
+    log_image_coverage_report,
+)
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+
+from performers.models import Performer
+
+EXIT_OK = 0
+EXIT_BELOW_THRESHOLD = 2
+
+DEFAULT_SCOPE = "week"
+SCOPE_CHOICES = (DEFAULT_SCOPE, "all")
+
+
+def _resolve_week_start(target_week: str | None) -> date:
+    """Return the Monday for the target week, defaulting to the upcoming Monday."""
+    if target_week:
+        try:
+            return datetime.strptime(target_week, "%Y-%m-%d").date()  # noqa: DTZ007
+        except ValueError as exc:
+            raise CommandError(f"--target-week must be YYYY-MM-DD, got {target_week!r}") from exc
+    today = date.today()  # noqa: DTZ011
+    days_until_monday = (7 - today.weekday()) % 7
+    if days_until_monday == 0:
+        days_until_monday = 7
+    return today + timedelta(days=days_until_monday)
+
+
+class Command(BaseCommand):
+    help = (
+        "Report performer image coverage and event_image coverage for the target week. "
+        "Exits with status 2 when performer coverage is below --threshold."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--target-week",
+            type=str,
+            default=None,
+            help="Monday (YYYY-MM-DD) of the target week. Default: upcoming Monday.",
+        )
+        parser.add_argument(
+            "--threshold",
+            type=float,
+            default=DEFAULT_PERFORMER_COVERAGE_THRESHOLD,
+            help=f"Performer coverage threshold 0-1 (default: {DEFAULT_PERFORMER_COVERAGE_THRESHOLD}).",
+        )
+        parser.add_argument(
+            "--scope",
+            choices=SCOPE_CHOICES,
+            default=DEFAULT_SCOPE,
+            help="week: performers scheduled in the target week. all: every Performer in the DB.",
+        )
+        parser.add_argument(
+            "--format",
+            choices=("text", "json"),
+            default="text",
+            help="Output format (default: text).",
+        )
+
+    def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003
+        threshold: float = options["threshold"]
+        scope: str = options["scope"]
+        output_format: str = options["format"]
+        week_start = _resolve_week_start(options["target_week"])
+        week_end = week_start + timedelta(days=7)
+
+        if scope == "week":
+            performers = list(
+                Performer.objects.filter(
+                    performance_schedules__performance_date__gte=week_start,
+                    performance_schedules__performance_date__lt=week_end,
+                ).distinct()
+            )
+        else:
+            performers = list(Performer.objects.all())
+
+        report = build_image_coverage_report(performers, week_start, threshold=threshold)
+        log_image_coverage_report(report, context=f"check_image_coverage:{scope}")
+
+        if output_format == "json":
+            payload = report.to_log_payload(context=f"check_image_coverage:{scope}")
+            payload["scope"] = scope
+            payload["performers_without_image"] = report.performers_without_image
+            self.stdout.write(json.dumps(payload, sort_keys=True))
+        else:
+            self._write_text_report(report, scope, week_start)
+
+        if report.below_threshold:
+            sys.exit(EXIT_BELOW_THRESHOLD)
+
+    def _write_text_report(self, report, scope: str, week_start: date) -> None:  # noqa: ANN001
+        self.stdout.write(f"Week starting: {week_start}")
+        self.stdout.write(f"Scope: {scope}")
+        self.stdout.write(
+            f"Performers with image: {report.performers_with_image}/{report.performer_total} "
+            f"({report.performer_coverage_ratio:.0%})"
+        )
+        self.stdout.write(
+            f"Schedules with event_image: {report.schedules_with_event_image}/{report.schedule_total} "
+            f"({report.schedule_coverage_ratio:.0%})"
+        )
+        if report.performers_without_image:
+            self.stdout.write("Performers missing artwork:")
+            for name in report.performers_without_image:
+                self.stdout.write(f"  - {name}")
+        if report.below_threshold:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"⚠ Performer coverage {report.performer_coverage_ratio:.0%} below threshold {report.threshold:.0%}"
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"✓ Performer coverage {report.performer_coverage_ratio:.0%} at or above "
+                    f"threshold {report.threshold:.0%}"
+                )
+            )

--- a/malcom/performers/tests/test_check_image_coverage.py
+++ b/malcom/performers/tests/test_check_image_coverage.py
@@ -1,0 +1,137 @@
+"""Tests for the check_image_coverage management command."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from io import StringIO
+
+from django.core.files.base import ContentFile
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from houses.models import LiveHouse, LiveHouseWebsite, PerformanceSchedule
+
+from performers.management.commands.check_image_coverage import (
+    EXIT_BELOW_THRESHOLD,
+    _resolve_week_start,
+)
+from performers.models import Performer
+
+
+def _make_performer(name: str, *, with_image: bool = False) -> Performer:
+    performer = Performer(name=name, name_kana=name, name_romaji=name)
+    performer._skip_image_fetch = True  # noqa: SLF001
+    performer.save()
+    if with_image:
+        performer.performer_image.save(f"{name}.jpg", ContentFile(b"fake"), save=True)
+    return performer
+
+
+def _make_venue() -> LiveHouse:
+    website = LiveHouseWebsite.objects.create(url="https://example.com/")
+    return LiveHouse.objects.create(
+        website=website,
+        name="Test Venue",
+        name_kana="テスト",
+        name_romaji="Test",
+        address="addr",
+        capacity=100,
+        opened_date=date(2000, 1, 1),
+    )
+
+
+class ResolveWeekStartTests(TestCase):
+    def test_explicit_week_start_parsed(self) -> None:
+        self.assertEqual(_resolve_week_start("2026-06-01"), date(2026, 6, 1))
+
+    def test_invalid_week_start_raises(self) -> None:
+        with self.assertRaises(CommandError):
+            _resolve_week_start("not-a-date")
+
+
+class CheckImageCoverageCommandTests(TestCase):
+    def setUp(self) -> None:
+        self.venue = _make_venue()
+        self.week_start = date(2026, 6, 1)
+
+    def _schedule_for(self, performer: Performer, *, with_image: bool = False) -> PerformanceSchedule:
+        schedule = PerformanceSchedule.objects.create(
+            live_house=self.venue,
+            performance_name="Show",
+            performance_date=date(2026, 6, 3),
+        )
+        schedule.performers.add(performer)
+        if with_image:
+            schedule.event_image.save(f"{performer.name}-flyer.jpg", ContentFile(b"flyer"), save=True)
+        return schedule
+
+    def test_text_output_when_above_threshold(self) -> None:
+        performer = _make_performer("HasArt", with_image=True)
+        self._schedule_for(performer, with_image=True)
+
+        out = StringIO()
+        call_command(
+            "check_image_coverage",
+            "--target-week=2026-06-01",
+            "--scope=week",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("Performers with image: 1/1", output)
+        self.assertIn("at or above", output)
+        self.assertIn("Schedules with event_image: 1/1", output)
+
+    def test_json_output_below_threshold_exits_non_zero(self) -> None:
+        # 2 of 10 performers (20%) have artwork — well below the 70% default.
+        for i in range(2):
+            self._schedule_for(_make_performer(f"HasArt{i}", with_image=True))
+        for i in range(8):
+            self._schedule_for(_make_performer(f"Missing{i}"))
+
+        out = StringIO()
+        with self.assertRaises(SystemExit) as exit_ctx:
+            call_command(
+                "check_image_coverage",
+                "--target-week=2026-06-01",
+                "--scope=week",
+                "--format=json",
+                stdout=out,
+            )
+
+        self.assertEqual(exit_ctx.exception.code, EXIT_BELOW_THRESHOLD)
+        payload = json.loads(out.getvalue().splitlines()[-1])
+        self.assertTrue(payload["below_threshold"])
+        self.assertEqual(payload["scope"], "week")
+        self.assertEqual(payload["performer_total"], 10)
+        self.assertEqual(payload["performers_with_image"], 2)
+        self.assertIn("performers_without_image", payload)
+        self.assertEqual(len(payload["performers_without_image"]), 8)
+
+    def test_scope_all_covers_every_performer(self) -> None:
+        _make_performer("WithArt", with_image=True)
+        _make_performer("NoArt")
+
+        out = StringIO()
+        call_command(
+            "check_image_coverage",
+            "--target-week=2026-06-01",
+            "--scope=all",
+            "--threshold=0.0",
+            "--format=json",
+            stdout=out,
+        )
+
+        payload = json.loads(out.getvalue().splitlines()[-1])
+        self.assertEqual(payload["performer_total"], 2)
+        self.assertEqual(payload["performers_with_image"], 1)
+
+    def test_zero_performers_does_not_exit_non_zero(self) -> None:
+        out = StringIO()
+        call_command(
+            "check_image_coverage",
+            "--target-week=2026-06-01",
+            "--scope=week",
+            stdout=out,
+        )
+        self.assertIn("Performers with image: 0/0", out.getvalue())

--- a/scripts/hakoake-check-image-coverage.sh
+++ b/scripts/hakoake-check-image-coverage.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# hakoake-check-image-coverage.sh — Alert when performer/event image coverage
+# drops below threshold. Runs after the nightly fetch_performer_images backfill
+# so missing coverage indicates the scraper itself is failing rather than a
+# normal nightly catch-up window. Exit code 2 (EXIT_BELOW_THRESHOLD) triggers
+# cron's mail-on-failure (or any wrapping alerting hook).
+set -euo pipefail
+
+export PATH="/home/monkut/.local/bin:$PATH"
+
+HAKOAKE_DIR="$HOME/projects/hakoake-backend/malcom"
+LOG_DIR="$HOME/projects/hakoake-backend/logs"
+mkdir -p "$LOG_DIR"
+
+TODAY=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+LOGFILE="$LOG_DIR/hakoake-check-image-coverage-${TODAY}.log"
+
+exec > >(tee "$LOGFILE") 2>&1
+
+cd "$HAKOAKE_DIR"
+
+echo "Checking image coverage for the upcoming week..."
+uv run python manage.py check_image_coverage --format text


### PR DESCRIPTION
Closes #56.

## Summary

- Adds `commons.image_coverage` with a reusable `ImageCoverageReport`: counts performers with at least one image and `PerformanceSchedule` rows with an `event_image` for the target week. Emits a structured `INFO` log; escalates to `WARNING` when the performer coverage ratio falls below the configured threshold (default 0.7).
- Wires the report into `post_weekly_playlist`: every run now logs the coverage summary before slides are generated and prints missing-artwork performer names to stdout. Replaces the previous silent fallback to the default background image.
- Adds `performers/management/commands/check_image_coverage.py` (text/JSON output, scope `week` or `all`). Exits with status 2 when coverage is below threshold so cron mail-on-failure can fire.
- Adds `scripts/hakoake-check-image-coverage.sh` as the cron-ready wrapper, paired with the existing nightly `hakoake-fetch-performer-images` job.

## Acceptance Criteria

- [x] Structured log summary emitted before each `post_weekly_playlist` run listing image coverage (`commons.image_coverage` INFO/WARNING line with payload).
- [x] Management command `check_image_coverage` exists; cron wrapper `scripts/hakoake-check-image-coverage.sh` invokes it daily.
- [x] Missing-image cases surfaced as warnings (`logger.warning` + non-zero exit + stdout `WARNING` style), no longer silent.

## Test plan

- [x] `cd malcom && uv run python manage.py test commons.tests.test_image_coverage performers.tests.test_check_image_coverage houses.tests.test_post_weekly_playlist --debug-mode` → 29 passing
- [x] `uv run poe test` → 426 tests passing
- [x] `uv run poe check` (ruff) → clean
- [ ] Smoke-run `uv run python manage.py check_image_coverage --scope week` against a real DB after deploy