### PR TITLE
feat(crawlers): add PitZeroCrawler for Shibuya PIT ZERO

### DIFF
--- a/malcom/houses/crawlers/__init__.py
+++ b/malcom/houses/crawlers/__init__.py
@@ -11,6 +11,7 @@ from .club_que import ClubQueCrawler
 from .garret import GarretCrawler
 from .fever_popo import FeverPopoCrawler
 from .shibuya_o_nest import ShibuyaONestCrawler
+from .pit_zero import PitZeroCrawler
 
 __all__ = [
     "LiveHouseWebsiteCrawler",
@@ -27,4 +28,5 @@ __all__ = [
     "GarretCrawler",
     "FeverPopoCrawler",
     "ShibuyaONestCrawler",
+    "PitZeroCrawler",
 ]

--- a/malcom/houses/crawlers/pit_zero.py
+++ b/malcom/houses/crawlers/pit_zero.py
@@ -1,0 +1,149 @@
+import logging
+import re
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin
+
+from django.utils import timezone
+
+from .crawler import CrawlerRegistry, LiveHouseWebsiteCrawler
+
+if TYPE_CHECKING:
+    from bs4 import Tag
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.pitzero.takeoff7.tokyo"
+_SCHEDULE_PATH = "/events"
+_MAX_EVENTS = 50
+
+
+def _parse_ecard_date(text: str) -> str | None:
+    """Parse date from ecard-date span text like '2026.6.17 WED' or '2026.6.17(WED)'."""
+    match = re.match(r"(\d{4})\.(\d{1,2})\.(\d{1,2})", text.strip())
+    if not match:
+        return None
+    year, month, day = int(match.group(1)), int(match.group(2)), int(match.group(3))
+    return f"{year:04d}-{month:02d}-{day:02d}"
+
+
+@CrawlerRegistry.register("PitZeroCrawler")
+class PitZeroCrawler(LiveHouseWebsiteCrawler):
+    """
+    Crawler for Shibuya PIT ZERO (https://www.pitzero.takeoff7.tokyo/).
+
+    Schedule page uses query param: /events?date=YYYY%2FMM
+    Site serves static HTML — no Playwright needed.
+    """
+
+    def extract_live_house_info(self, html_content: str) -> dict:
+        return {
+            "name": "Shibuya PIT ZERO",
+            "name_kana": "シブヤピットゼロ",
+            "name_romaji": "Shibuya Pit Zero",
+            "address": "〒150-0042 東京都渋谷区宇田川町32-12 アソルティ渋谷B1F",
+            "phone_number": "03-3770-7755",
+            "capacity": 0,
+            "opened_date": None,
+        }
+
+    def find_schedule_link(self, html_content: str) -> str | None:
+        current_date = timezone.localdate()
+        return f"{_BASE_URL}{_SCHEDULE_PATH}?date={current_date.year}%2F{current_date.month:02d}"
+
+    def find_next_month_link(self, html_content: str) -> str | None:
+        current_date = timezone.localdate()
+        next_month = (current_date.month % 12) + 1
+        next_year = current_date.year if next_month > current_date.month else current_date.year + 1
+        return f"{_BASE_URL}{_SCHEDULE_PATH}?date={next_year}%2F{next_month:02d}"
+
+    def extract_performance_schedules(self, html_content: str) -> list[dict]:  # noqa: PLR0912
+        """Parse event cards from the schedule list page and enrich with detail-page times."""
+        soup = self.create_soup(html_content)
+        cards = soup.find_all("a", class_="ecard")
+        logger.debug(f"Found {len(cards)} event cards on PitZero schedule page")
+
+        schedules = []
+        for card in cards[:_MAX_EVENTS]:
+            try:
+                schedule = self._parse_event_card(card)
+                if not schedule:
+                    continue
+                detail_url = schedule.pop("_detail_url", None)
+                if detail_url:
+                    self._enrich_from_detail(schedule, detail_url)
+                schedules.append(schedule)
+            except Exception:  # noqa: BLE001
+                logger.exception("Error parsing PitZero event card")
+
+        logger.info(f"Extracted {len(schedules)} schedules from PitZero schedule page")
+        return schedules
+
+    def _parse_event_card(self, card: "Tag") -> dict | None:
+        """Parse one <a class='ecard'> card into a schedule dict."""
+        href = card.get("href", "")
+        if not href:
+            return None
+
+        date_span = card.find("span", class_="ecard-date")
+        if not date_span:
+            return None
+        date_str = _parse_ecard_date(date_span.get_text(strip=True))
+        if not date_str:
+            return None
+
+        title_span = card.find("span", class_="ecard-title")
+        event_name = title_span.get_text(strip=True) if title_span else None
+
+        artists_span = card.find("span", class_="ecard-artists")
+        performers: list[str] = []
+        if artists_span:
+            raw = artists_span.get_text(strip=True)
+            performers = [p.strip() for p in re.split(r"\s*/\s*", raw) if p.strip()]
+
+        img = card.find("img", class_="ecard-img")
+        event_image_url = img["src"] if img and img.get("src") else None
+
+        schedule: dict = {
+            "date": date_str,
+            "open_time": None,
+            "start_time": None,
+            "performers": performers,
+            "_detail_url": urljoin(_BASE_URL, href),
+        }
+        if event_name:
+            schedule["performance_name"] = event_name
+        if event_image_url:
+            schedule["event_image_url"] = event_image_url
+        return schedule
+
+    def _enrich_from_detail(self, schedule: dict, detail_url: str) -> None:
+        """Fetch event detail page and add open/start times and refined artist list."""
+        detail_html = self._fetch_event_detail_html(detail_url)
+        if not detail_html:
+            return
+
+        soup = self.create_soup(detail_html)
+
+        time_span = soup.find("span", class_="badge-time")
+        if time_span:
+            times = self._extract_open_start_times(time_span.get_text(strip=True))
+            if times["open_time"]:
+                schedule["open_time"] = times["open_time"]
+            if times["start_time"]:
+                schedule["start_time"] = times["start_time"]
+
+        artist_nms = soup.find_all("span", class_="artist-nm")
+        if artist_nms:
+            schedule["performers"] = [nm.get_text(strip=True) for nm in artist_nms if nm.get_text(strip=True)]
+
+        ticket_block = soup.find("div", class_="detail-ticket")
+        if ticket_block:
+            schedule["context"] = ticket_block.get_text(" ", strip=True)
+
+    def _fetch_event_detail_html(self, detail_url: str) -> str | None:
+        """Fetch detail page HTML, returning None on any failure."""
+        try:
+            return self.fetch_page(detail_url)
+        except Exception:  # noqa: BLE001
+            logger.warning(f"Failed to fetch PitZero detail page: {detail_url}")
+            return None

--- a/malcom/houses/tests/test_crawlers_pit_zero.py
+++ b/malcom/houses/tests/test_crawlers_pit_zero.py
@@ -1,0 +1,234 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from houses.crawlers import PitZeroCrawler
+from houses.crawlers.pit_zero import _parse_ecard_date
+from houses.definitions import WebsiteProcessingState
+from houses.models import LiveHouseWebsite
+
+# ---- fixture HTML ----
+
+SCHEDULE_LIST_HTML = """\
+<!DOCTYPE html>
+<html>
+<head><title>SCHEDULE</title></head>
+<body>
+<section class="sec schedule-page">
+  <div class="month-filter">
+    <a class="month-btn" href="/events?date=2026%2F05">5月</a>
+    <a class="month-btn active" href="/events?date=2026%2F06">6月</a>
+    <a class="month-btn" href="/events?date=2026%2F07">7月</a>
+  </div>
+
+  <div class="events-grid">
+    <a class="ecard schedule-card" href="/events/10001">
+      <img class="ecard-img" alt="Event One" src="https://example.com/img1.jpg" />
+      <span class="ecard-body">
+        <span class="ecard-date">2026.6.10 WED</span>
+        <span class="ecard-title">Summer Night Live</span>
+        <span class="ecard-artists">BandAlpha / BandBeta</span>
+        <span class="ecard-price">ADV ¥3,000 / DOOR ¥3,500</span>
+      </span>
+    </a>
+    <a class="ecard schedule-card" href="/events/10002">
+      <img class="ecard-img" alt="Event Two" src="https://example.com/img2.jpg" />
+      <span class="ecard-body">
+        <span class="ecard-date">2026.6.25 THU</span>
+        <span class="ecard-title">Rock Festival</span>
+        <span class="ecard-artists">ArtistOne / ArtistTwo / ArtistThree</span>
+        <span class="ecard-price">ADV ¥4,000 / DOOR ¥4,500</span>
+      </span>
+    </a>
+  </div>
+</section>
+</body>
+</html>
+"""
+
+EVENT_DETAIL_HTML = """\
+<!DOCTYPE html>
+<html>
+<body>
+<main class="ft-detail">
+  <div class="detail-badge">
+    <span class="badge-date">2026.6.10(WED)</span>
+    <span class="badge-time">OPEN 18:30 / START 19:00</span>
+  </div>
+  <h1 class="detail-h1">Summer Night Live</h1>
+  <div class="detail-grid">
+    <div class="detail-block detail-artists">
+      <p class="detail-col-title">LINE UP</p>
+      <div class="artist-line">
+        <span class="artist-role">ARTIST</span>
+        <span class="artist-nm">BandAlpha</span>
+      </div>
+      <div class="artist-line">
+        <span class="artist-role">ARTIST</span>
+        <span class="artist-nm">BandBeta</span>
+      </div>
+    </div>
+    <div class="detail-block detail-ticket">
+      <div class="ticket-row">
+        <span class="ticket-label">前売券</span>
+        <span class="ticket-price">¥3,000</span>
+      </div>
+      <div class="ticket-row ticket-row-door">
+        <span class="ticket-label">当日券</span>
+        <span class="ticket-price">¥3,500</span>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>
+"""
+
+EMPTY_SCHEDULE_HTML = """\
+<!DOCTYPE html>
+<html><body>
+<div class="events-grid"></div>
+<p class="empty-message">現在公開中の公演はありません。</p>
+</body></html>
+"""
+
+
+class TestParsEcardDate(TestCase):
+    """Unit tests for the module-level _parse_ecard_date helper."""
+
+    def test_standard_format(self) -> None:
+        self.assertEqual(_parse_ecard_date("2026.6.17 WED"), "2026-06-17")
+
+    def test_parenthesised_day(self) -> None:
+        self.assertEqual(_parse_ecard_date("2026.6.17(WED)"), "2026-06-17")
+
+    def test_single_digit_month_and_day(self) -> None:
+        self.assertEqual(_parse_ecard_date("2026.1.5 MON"), "2026-01-05")
+
+    def test_double_digit_month_and_day(self) -> None:
+        self.assertEqual(_parse_ecard_date("2026.12.31 THU"), "2026-12-31")
+
+    def test_invalid_returns_none(self) -> None:
+        self.assertIsNone(_parse_ecard_date("not a date"))
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(_parse_ecard_date(""))
+
+
+class TestPitZeroCrawler(TestCase):
+    """Tests for PitZeroCrawler parsing logic."""
+
+    def setUp(self) -> None:
+        self.website = LiveHouseWebsite.objects.create(
+            url="https://www.pitzero.takeoff7.tokyo/",
+            state=WebsiteProcessingState.NOT_STARTED,
+            crawler_class="PitZeroCrawler",
+        )
+        self.crawler = PitZeroCrawler(self.website)
+
+    def test_extract_live_house_info(self) -> None:
+        info = self.crawler.extract_live_house_info("")
+        self.assertEqual(info["name"], "Shibuya PIT ZERO")
+        self.assertEqual(info["name_kana"], "シブヤピットゼロ")
+        self.assertEqual(info["name_romaji"], "Shibuya Pit Zero")
+        self.assertIn("渋谷区宇田川町", info["address"])
+        self.assertEqual(info["phone_number"], "03-3770-7755")
+
+    def test_find_schedule_link_contains_current_month(self) -> None:
+        today = timezone.localdate()
+        link = self.crawler.find_schedule_link("")
+        self.assertIn(str(today.year), link)
+        self.assertIn(f"{today.month:02d}", link)
+        self.assertIn("/events?date=", link)
+
+    def test_find_next_month_link(self) -> None:
+        today = timezone.localdate()
+        next_month = (today.month % 12) + 1
+        next_year = today.year if next_month > today.month else today.year + 1
+        link = self.crawler.find_next_month_link("")
+        self.assertIn(str(next_year), link)
+        self.assertIn(f"{next_month:02d}", link)
+
+    def test_parse_event_card_basic(self) -> None:
+        soup = self.crawler.create_soup(SCHEDULE_LIST_HTML)
+        cards = soup.find_all("a", class_="ecard")
+        self.assertEqual(len(cards), 2)  # noqa: PLR2004
+
+        schedule = self.crawler._parse_event_card(cards[0])
+        self.assertIsNotNone(schedule)
+        self.assertEqual(schedule["date"], "2026-06-10")
+        self.assertEqual(schedule["performance_name"], "Summer Night Live")
+        self.assertIn("BandAlpha", schedule["performers"])
+        self.assertIn("BandBeta", schedule["performers"])
+        self.assertEqual(schedule["event_image_url"], "https://example.com/img1.jpg")
+        self.assertIn("_detail_url", schedule)
+
+    def test_parse_event_card_multiple_artists(self) -> None:
+        soup = self.crawler.create_soup(SCHEDULE_LIST_HTML)
+        cards = soup.find_all("a", class_="ecard")
+        schedule = self.crawler._parse_event_card(cards[1])
+        self.assertIsNotNone(schedule)
+        self.assertEqual(len(schedule["performers"]), 3)  # noqa: PLR2004
+        self.assertIn("ArtistOne", schedule["performers"])
+        self.assertIn("ArtistThree", schedule["performers"])
+
+    def test_enrich_from_detail_sets_times(self) -> None:
+        schedule: dict = {
+            "date": "2026-06-10",
+            "open_time": None,
+            "start_time": None,
+            "performers": ["BandAlpha", "BandBeta"],
+        }
+        self.crawler._enrich_from_detail(schedule, "https://www.pitzero.takeoff7.tokyo/events/10001")
+        # _enrich_from_detail calls _fetch_event_detail_html internally;
+        # since there's no real server here, it returns None and the schedule is unchanged.
+        # Test structure: just verify it doesn't raise and doesn't overwrite with garbage.
+        self.assertIn("date", schedule)
+
+    def test_enrich_from_detail_parses_times(self) -> None:
+        """Verify _enrich_from_detail correctly parses times from fixture detail HTML."""
+        schedule: dict = {
+            "date": "2026-06-10",
+            "open_time": None,
+            "start_time": None,
+            "performers": [],
+        }
+        with patch.object(self.crawler, "_fetch_event_detail_html", return_value=EVENT_DETAIL_HTML):
+            self.crawler._enrich_from_detail(schedule, "https://www.pitzero.takeoff7.tokyo/events/10001")
+
+        self.assertEqual(schedule["open_time"], "18:30")
+        self.assertEqual(schedule["start_time"], "19:00")
+        self.assertIn("BandAlpha", schedule["performers"])
+        self.assertIn("BandBeta", schedule["performers"])
+        self.assertIn("context", schedule)
+
+    def test_extract_performance_schedules_no_detail_fetch(self) -> None:
+        """extract_performance_schedules returns events even when detail fetch fails."""
+        with patch.object(self.crawler, "_fetch_event_detail_html", return_value=None):
+            schedules = self.crawler.extract_performance_schedules(SCHEDULE_LIST_HTML)
+
+        self.assertEqual(len(schedules), 2)  # noqa: PLR2004
+        self.assertEqual(schedules[0]["date"], "2026-06-10")
+        self.assertIn("BandAlpha", schedules[0]["performers"])
+        self.assertEqual(schedules[1]["date"], "2026-06-25")
+
+    def test_extract_performance_schedules_with_detail(self) -> None:
+        """extract_performance_schedules enriches times from detail page."""
+        with patch.object(self.crawler, "_fetch_event_detail_html", return_value=EVENT_DETAIL_HTML):
+            schedules = self.crawler.extract_performance_schedules(SCHEDULE_LIST_HTML)
+
+        self.assertEqual(len(schedules), 2)  # noqa: PLR2004
+        self.assertEqual(schedules[0]["open_time"], "18:30")
+        self.assertEqual(schedules[0]["start_time"], "19:00")
+
+    def test_extract_performance_schedules_empty_grid(self) -> None:
+        with patch.object(self.crawler, "_fetch_event_detail_html", return_value=None):
+            schedules = self.crawler.extract_performance_schedules(EMPTY_SCHEDULE_HTML)
+        self.assertEqual(schedules, [])
+
+    def test_fetch_event_detail_html_returns_none_on_error(self) -> None:
+        """_fetch_event_detail_html returns None instead of raising on network error."""
+        with patch.object(self.crawler.session, "get", side_effect=ConnectionError("timeout")):
+            result = self.crawler._fetch_event_detail_html("https://www.pitzero.takeoff7.tokyo/events/99")
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary

- Implements `PitZeroCrawler` in `malcom/houses/crawlers/pit_zero.py`
- Schedule page is static HTML at `/events?date=YYYY%2FMM` — no Playwright required
- Per-event detail pages fetched to extract `OPEN / START` times from `<span class="badge-time">`
- Graceful degradation: detail page failures are logged and the event is retained with `None` times
- Venue info hardcoded (name, kana, romaji, address, phone) matching footer data
- Registered in `crawlers/__init__.py`

## Test plan

- [x] 17 unit tests in `test_crawlers_pit_zero.py` — all passing
- [x] `ruff check` and `ruff format` clean
- [x] Pre-commit hooks pass

## LiveHouseWebsite registration

After merge, register the venue:
```bash
cd malcom && uv run python manage.py addwebsite https://www.pitzero.takeoff7.tokyo/
# then set crawler_class to "PitZeroCrawler" via Django admin or:
# LiveHouseWebsite.objects.filter(url__contains="pitzero").update(crawler_class="PitZeroCrawler")
```

Closes #88