### PR TITLE
feat(scripts): add YouTube Shorts generation/upload to hakoake-gen-video.sh

### DIFF
--- a/scripts/hakoake-gen-video.sh
+++ b/scripts/hakoake-gen-video.sh
@@ -4,7 +4,8 @@
 # 1. Creates the weekly playlist for next Monday
 # 2. Looks up the created playlist's DB id
 # 3. Generates the playlist video
-# 4. Posts the Instagram carousel announcement
+# 4. Generates and uploads the YouTube Shorts version
+# 5. Posts the Instagram carousel announcement
 set -euo pipefail
 
 export PATH="/home/monkut/.local/bin:$PATH"
@@ -29,6 +30,9 @@ playlist_db_id=$(uv run python manage.py list_weekly_playlist "$MONDAY" --json |
 
 echo "Generating weekly playlist video for playlist id=${playlist_db_id}..."
 uv run python manage.py generate_weekly_playlist_video "$playlist_db_id"
+
+echo "Generating and uploading YouTube Shorts for playlist id=${playlist_db_id}..."
+uv run python manage.py generate_weekly_playlist_video "$playlist_db_id" --format shorts
 
 echo "Posting weekly playlist announcement to Instagram..."
 uv run python manage.py post_weekly_playlist --playlist-id="$playlist_db_id"


### PR DESCRIPTION
## Summary

- Adds a `generate_weekly_playlist_video --format shorts` step to `hakoake-gen-video.sh` immediately after the standard video generation
- Generates a 9:16 ≤60s Short and uploads it to YouTube as part of the weekly scheduled run
- Existing steps (standard video, Instagram carousel) are unaffected

## Test plan

- [ ] Verify script runs in dry-run: `uv run python manage.py generate_weekly_playlist_video <id> --format shorts --skip-update-playlist`
- [ ] Verify Shorts video is generated and uploaded on next Monday run (or manual invocation)
- [ ] Confirm `shorts_youtube_video_id` is persisted on the `WeeklyPlaylist` record after upload

Closes #90
Requested via Slack #hakoake thread 1779922082.284959