### PR TITLE
feat(instagram-story): generate and post Story video following Shorts structure

### DIFF
--- a/malcom/commons/instagram_post.py
+++ b/malcom/commons/instagram_post.py
@@ -159,6 +159,36 @@ def post_carousel(
     return publish_media(user_id, access_token, creation_id)
 
 
+def create_story_container(user_id: str, access_token: str, video_url: str) -> str:
+    """Create a Stories media container from a public video URL. Returns container_id."""
+    url = f"{INSTAGRAM_API_BASE}/{user_id}/media"
+    params = {
+        "media_type": "STORIES",
+        "video_url": video_url,
+        "access_token": access_token,
+    }
+    response = requests.post(url, params=params, timeout=30)
+    response.raise_for_status()
+    container_id = response.json()["id"]
+    logger.debug(f"Created story container: {container_id} (video_url={video_url})")
+    return container_id
+
+
+def post_story(user_id: str, access_token: str, video_bytes: bytes, filename: str) -> str:
+    """Post a video as an Instagram Story. Returns the published story_id.
+
+    Args:
+        user_id: Instagram user ID
+        access_token: Valid Instagram access token
+        video_bytes: MP4 video file bytes (H.264, AAC audio, 9:16, ≤60s, ≤100MB)
+        filename: Filename used when uploading to the CDN (e.g. "story_20250529.mp4")
+    """
+    public_url = upload_to_litterbox(video_bytes, filename)
+    container_id = create_story_container(user_id, access_token, public_url)
+    wait_for_container_finished(container_id, access_token)
+    return publish_media(user_id, access_token, container_id)
+
+
 def build_caption(description: str, playlist_url: str, extra_hashtags: tuple[str, ...] = ()) -> str:
     """Build an Instagram caption from a playlist description.
 

--- a/malcom/houses/functions.py
+++ b/malcom/houses/functions.py
@@ -847,6 +847,9 @@ SHORTS_AUDIO_FADE_DURATION = 0.5
 SHORTS_MIN_NAME_FONT_SIZE = 32
 PERFORMER_SAMPLES_DIR = "performer_samples"
 
+STORY_MAX_PERFORMERS = 5
+STORY_MAX_TOTAL_DURATION = 60.0  # Instagram Graph API Story duration limit
+
 
 def download_performer_song_audio(song: PerformerSong, *, force: bool = False) -> Path | None:
     """Download audio from a performer's YouTube song, caching to data/performer_samples/<song_id>.mp3.
@@ -1517,12 +1520,14 @@ def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915, C901, PLR0912
     timestamp_format: str,
     max_performers: int = SHORTS_MAX_PERFORMERS,
     intro_voiceover: str | None = None,
+    include_closing: bool = True,
 ) -> Path:
     """Generate a vertical 9:16 YouTube Shorts video (≤70s) from a playlist.
 
     Shorts pacing keeps the runtime under 70s by capping the number of
     performer slides and using shorter fixed durations per slide. Each slide
     has a TTS voice-over mixed with background/song audio.
+    Set include_closing=False to omit the closing slide (e.g. for Instagram Stories).
     """
     temp_dir = Path(tempfile.mkdtemp())
     logger.info(f"Created temp directory: {temp_dir}")
@@ -1530,8 +1535,9 @@ def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915, C901, PLR0912
     entry_set = getattr(playlist, entry_set_name).select_related("song__performer")
     all_entries = list(entry_set.order_by("position"))
 
-    # Budget: leave room for intro + closing inside SHORTS_MAX_TOTAL_DURATION.
-    budget = SHORTS_MAX_TOTAL_DURATION - SHORTS_INTRO_DURATION - SHORTS_CLOSING_DURATION
+    # Budget: leave room for intro (+ optional closing) inside SHORTS_MAX_TOTAL_DURATION.
+    closing_budget = SHORTS_CLOSING_DURATION if include_closing else 0.0
+    budget = SHORTS_MAX_TOTAL_DURATION - SHORTS_INTRO_DURATION - closing_budget
     capacity_by_duration = int(budget // SHORTS_PERFORMER_DURATION)
     cap = max(1, min(max_performers, capacity_by_duration))
     entries = all_entries[:cap]
@@ -1605,15 +1611,16 @@ def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915, C901, PLR0912
         slides.append((performer_path, SHORTS_PERFORMER_DURATION))
         performer_entries.append((performer_path, SHORTS_PERFORMER_DURATION, entry.song, voiceover_text))
 
-    # 3. Closing slide
-    logger.info("Creating shorts closing slide...")
-    closing_slide = render_shorts_closing_slide(
-        closing_text=closing_text,
-        channel_url="https://www.youtube.com/@hakkoakkei",
-    )
-    closing_path = temp_dir / "shorts_closing.png"
-    closing_slide.save(closing_path)
-    slides.append((closing_path, SHORTS_CLOSING_DURATION))
+    # 3. Closing slide (omitted for formats that don't need it, e.g. Instagram Stories)
+    if include_closing:
+        logger.info("Creating shorts closing slide...")
+        closing_slide = render_shorts_closing_slide(
+            closing_text=closing_text,
+            channel_url="https://www.youtube.com/@hakkoakkei",
+        )
+        closing_path = temp_dir / "shorts_closing.png"
+        closing_slide.save(closing_path)
+        slides.append((closing_path, SHORTS_CLOSING_DURATION))
 
     # Generate TTS voice-over audio files
     async def _gen_tts(text: str, path: Path) -> None:
@@ -1718,8 +1725,8 @@ def _generate_playlist_video_shorts(  # noqa: PLR0913, PLR0915, C901, PLR0912
 
             performer_offset += slide_duration
 
-        # Closing: background music with fade-out
-        if background_music_path.exists():
+        # Closing: background music with fade-out (only when closing slide is included)
+        if include_closing and background_music_path.exists():
             bg_closing = AudioFileClip(str(background_music_path))
             bg_closing = _loop_to_duration(bg_closing, SHORTS_CLOSING_DURATION)
             bg_closing = bg_closing.with_volume_scaled(0.4)
@@ -1788,4 +1795,30 @@ def generate_weekly_playlist_video_shorts(
         timestamp_format="%Y%m%d",
         max_performers=max_performers,
         intro_voiceover=intro_voiceover,
+    )
+
+
+def generate_weekly_playlist_video_story(
+    playlist: WeeklyPlaylist,
+    max_performers: int = STORY_MAX_PERFORMERS,
+) -> Path:
+    """Generate an Instagram Story (9:16, ≤55s) video for a weekly playlist.
+
+    Structure: intro (5s) + up to 5 performer slides (10s each) = ≤55s.
+    Closing slide is omitted to stay within the 60s Instagram Graph API limit.
+    """
+    week_start = playlist.date
+    intro_voiceover = f"Bands playing the week of {week_start.strftime('%B')} {_ordinal_day(week_start.day)}"
+    return _generate_playlist_video_shorts(
+        playlist=playlist,
+        entry_set_name="weeklyplaylistentry_set",
+        date_start=week_start,
+        date_end=week_start + timezone.timedelta(days=7),
+        title_label=f"WEEK / {week_start.strftime('%b %-d').upper()}",
+        closing_text="",
+        filename_prefix="playlist_story_week_",
+        timestamp_format="%Y%m%d",
+        max_performers=max_performers,
+        intro_voiceover=intro_voiceover,
+        include_closing=False,
     )

--- a/malcom/houses/management/commands/generate_weekly_playlist_video.py
+++ b/malcom/houses/management/commands/generate_weekly_playlist_video.py
@@ -2,14 +2,22 @@
 
 from pathlib import Path
 
+from commons.instagram_post import post_story
+from commons.instagram_utils import get_instagram_token
 from commons.youtube_utils import insert_video_at_position, post_video_comment, upload_video_to_youtube
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandParser
 from django.utils import timezone
-from houses.functions import generate_weekly_playlist_video, generate_weekly_playlist_video_shorts
+from houses.functions import (
+    generate_weekly_playlist_video,
+    generate_weekly_playlist_video_shorts,
+    generate_weekly_playlist_video_story,
+)
 from houses.models import WeeklyPlaylist
 
 VIDEO_FORMAT_STANDARD = "standard"
 VIDEO_FORMAT_SHORTS = "shorts"
+VIDEO_FORMAT_STORY = "story"
 
 
 class Command(BaseCommand):
@@ -44,12 +52,13 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--format",
-            choices=[VIDEO_FORMAT_STANDARD, VIDEO_FORMAT_SHORTS],
+            choices=[VIDEO_FORMAT_STANDARD, VIDEO_FORMAT_SHORTS, VIDEO_FORMAT_STORY],
             default=VIDEO_FORMAT_STANDARD,
             dest="video_format",
             help=(
                 "Output format: 'standard' for 1920x1080 long-form, "
-                "'shorts' for 1080x1920 9:16 ≤60s YouTube Shorts (no narration)"
+                "'shorts' for 1080x1920 9:16 ≤60s YouTube Shorts, "
+                "'story' for 1080x1920 9:16 ≤55s Instagram Story (5 performers, no closing)"
             ),
         )
 
@@ -140,6 +149,66 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.SUCCESS("Posted playlist description as comment."))
             else:
                 self.stderr.write(self.style.WARNING("Failed to post comment — manual comment may be needed."))
+            return
+
+        if video_format == VIDEO_FORMAT_STORY:
+            self.stdout.write("Format: story (9:16, ≤55s, Instagram Story)")
+
+            if not force and playlist.instagram_story_id:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Story already posted (story_id={playlist.instagram_story_id}); skipping. "
+                        f"Pass --force to re-post."
+                    )
+                )
+                return
+
+            if force and playlist.instagram_story_id:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"--force: clearing previously stored story state "
+                        f"(previous story_id={playlist.instagram_story_id!r})."
+                    )
+                )
+                playlist.instagram_story_id = ""
+                playlist.save(update_fields=["instagram_story_id"])
+
+            story_filepath = generate_weekly_playlist_video_story(playlist)
+            self.stdout.write(self.style.SUCCESS("\n=== Story Video Generated ===\n"))
+            self.stdout.write(f"Video saved to: {story_filepath}")
+
+            if skip_update_playlist:
+                self.stdout.write("Skipping Instagram Story post (--skip-update-playlist)")
+                return
+
+            self.stdout.write("Posting to Instagram Story...")
+            if not settings.INSTAGRAM_USER_ID:
+                self.stderr.write(self.style.ERROR("INSTAGRAM_USER_ID not set in .env"))
+                return
+
+            cert_file = settings.OAUTH_LOCALHOST_CERT
+            key_file = settings.OAUTH_LOCALHOST_KEY
+            token_cache = cert_file.parent / "instagram_token.json"
+            try:
+                token = get_instagram_token(cert_file, key_file, token_cache)
+            except Exception as exc:  # noqa: BLE001
+                self.stderr.write(self.style.ERROR(f"Failed to obtain Instagram token: {exc}"))
+                return
+            user_id = settings.INSTAGRAM_USER_ID
+            access_token = token.access_token
+
+            week_str = playlist.date.strftime("%Y%m%d")
+            story_filename = f"story_{week_str}.mp4"
+            video_bytes = story_filepath.read_bytes()
+            try:
+                story_id = post_story(user_id, access_token, video_bytes, story_filename)
+            except Exception as exc:  # noqa: BLE001
+                self.stderr.write(self.style.ERROR(f"Failed to post Instagram Story: {exc}"))
+                return
+
+            playlist.instagram_story_id = story_id
+            playlist.save(update_fields=["instagram_story_id"])
+            self.stdout.write(self.style.SUCCESS(f"Instagram Story posted: {story_id}"))
             return
 
         # Idempotency branches — only relevant when we would otherwise upload/insert.

--- a/malcom/houses/migrations/0015_weeklyplaylist_instagram_story_id.py
+++ b/malcom/houses/migrations/0015_weeklyplaylist_instagram_story_id.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('houses', '0014_weeklyplaylist_shorts_video_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='weeklyplaylist',
+            name='instagram_story_id',
+            field=models.CharField(blank=True, default='', max_length=100),
+        ),
+    ]

--- a/malcom/houses/models.py
+++ b/malcom/houses/models.py
@@ -161,6 +161,7 @@ class WeeklyPlaylist(TimestampedModel):
     intro_video_inserted_datetime = models.DateTimeField(null=True, blank=True)
     shorts_youtube_video_id = models.CharField(max_length=100, blank=True, default="")
     instagram_post_id = models.CharField(max_length=100, blank=True, default="")
+    instagram_story_id = models.CharField(max_length=100, blank=True, default="")
 
 
 class WeeklyPlaylistEntry(TimestampedModel):

--- a/malcom/houses/tests/test_generate_weekly_playlist_video_command.py
+++ b/malcom/houses/tests/test_generate_weekly_playlist_video_command.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from houses.models import WeeklyPlaylist
@@ -266,3 +266,95 @@ class TestGenerateWeeklyPlaylistVideoCommand(TestCase):
         self.playlist.refresh_from_db()
         self.assertEqual(self.playlist.intro_youtube_video_id, "persisted_vid")
         self.assertIsNone(self.playlist.intro_video_inserted_datetime)
+
+
+@override_settings(INSTAGRAM_USER_ID="test_ig_user_id")
+class TestGenerateWeeklyPlaylistVideoStoryFormat(TestCase):
+    def setUp(self) -> None:
+        self.playlist = WeeklyPlaylist.objects.create(
+            date=date(2026, 3, 30),
+            youtube_playlist_id="PLtest123",
+            youtube_playlist_url="https://www.youtube.com/playlist?list=PLtest123",
+        )
+
+    @patch("houses.management.commands.generate_weekly_playlist_video.post_story")
+    @patch("houses.management.commands.generate_weekly_playlist_video.get_instagram_token")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video_story")
+    def test_format_story_generates_and_posts_to_instagram(
+        self,
+        mock_story_gen: MagicMock,
+        mock_get_token: MagicMock,
+        mock_post_story: MagicMock,
+    ) -> None:
+        """AC: --format story generates the story video and posts it to Instagram."""
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as tmp_video:
+            mock_story_gen.return_value = Path(tmp_video.name)
+            mock_token = MagicMock()
+            mock_token.access_token = "test_token"
+            mock_get_token.return_value = mock_token
+            mock_post_story.return_value = "story_12345"
+
+            call_command(
+                "generate_weekly_playlist_video",
+                str(self.playlist.id),
+                format="story",
+            )
+
+        mock_story_gen.assert_called_once_with(self.playlist)
+        mock_post_story.assert_called_once()
+        self.playlist.refresh_from_db()
+        self.assertEqual(self.playlist.instagram_story_id, "story_12345")
+
+    @patch("houses.management.commands.generate_weekly_playlist_video.post_story")
+    @patch("houses.management.commands.generate_weekly_playlist_video.get_instagram_token")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video_story")
+    def test_format_story_skips_if_already_posted(
+        self,
+        mock_story_gen: MagicMock,
+        mock_get_token: MagicMock,
+        mock_post_story: MagicMock,
+    ) -> None:
+        """AC: --format story skips posting if instagram_story_id is already set."""
+        self.playlist.instagram_story_id = "already_posted_id"
+        self.playlist.save(update_fields=["instagram_story_id"])
+
+        call_command(
+            "generate_weekly_playlist_video",
+            str(self.playlist.id),
+            format="story",
+        )
+
+        mock_story_gen.assert_not_called()
+        mock_post_story.assert_not_called()
+
+    @patch("houses.management.commands.generate_weekly_playlist_video.post_story")
+    @patch("houses.management.commands.generate_weekly_playlist_video.get_instagram_token")
+    @patch("houses.management.commands.generate_weekly_playlist_video.generate_weekly_playlist_video_story")
+    def test_format_story_force_re_posts(
+        self,
+        mock_story_gen: MagicMock,
+        mock_get_token: MagicMock,
+        mock_post_story: MagicMock,
+    ) -> None:
+        """AC: --format story --force re-posts even when instagram_story_id is set."""
+        self.playlist.instagram_story_id = "old_story_id"
+        self.playlist.save(update_fields=["instagram_story_id"])
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as tmp_video:
+            mock_story_gen.return_value = Path(tmp_video.name)
+            mock_token = MagicMock()
+            mock_token.access_token = "test_token"
+            mock_get_token.return_value = mock_token
+            mock_post_story.return_value = "new_story_id"
+
+            call_command(
+                "generate_weekly_playlist_video",
+                str(self.playlist.id),
+                format="story",
+                force=True,
+            )
+
+        mock_story_gen.assert_called_once()
+        mock_post_story.assert_called_once()
+        self.playlist.refresh_from_db()
+        self.assertEqual(self.playlist.instagram_story_id, "new_story_id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ unsafe-fixes = false
 
 [tool.ruff.lint]
 select = ["ALL"]
-extend-per-file-ignores = { "**/__init__.py" = ["I", "F403"] }
+extend-per-file-ignores = { "**/__init__.py" = ["I", "F403"], "**/tests/**" = ["S105", "S106", "S107"] }
 extend-safe-fixes = [
     "D200",  # unnecessary-multiline-docstring
     "ANN204"  # missing-return-type-special-method (__init__)

--- a/scripts/hakoake-gen-video.sh
+++ b/scripts/hakoake-gen-video.sh
@@ -34,6 +34,9 @@ uv run python manage.py generate_weekly_playlist_video "$playlist_db_id"
 echo "Generating and uploading YouTube Shorts for playlist id=${playlist_db_id}..."
 uv run python manage.py generate_weekly_playlist_video "$playlist_db_id" --format shorts
 
+echo "Posting Instagram Story for playlist id=${playlist_db_id}..."
+uv run python manage.py generate_weekly_playlist_video "$playlist_db_id" --format story
+
 echo "Posting weekly playlist announcement to Instagram..."
 uv run python manage.py post_weekly_playlist --playlist-id="$playlist_db_id"
 


### PR DESCRIPTION
## Summary

- Adds `--format story` to `generate_weekly_playlist_video` command, generating a 9:16 vertical video (≤55s) and posting it to Instagram as a Story
- Reuses the Shorts rendering pipeline with `include_closing=False` and `max_performers=5` — gives 5s intro + 5×10s = 55s total (within the 60s Instagram Graph API limit)
- Music per slide preserved — same baked-in AAC audio approach as Shorts
- Full idempotency guard via `instagram_story_id` field on `WeeklyPlaylist` + `--force` override
- Wired into `hakoake-gen-video.sh` as a new step between Shorts and carousel post

## Duration math
| Component | Duration |
|---|---|
| Intro | 5s |
| 5 performer slides | 50s |
| Closing (omitted) | 0s |
| **Total** | **55s** ✓ |

## Changes
- `functions.py`: `include_closing` param on `_generate_playlist_video_shorts`; new `generate_weekly_playlist_video_story()` wrapper; new `STORY_MAX_PERFORMERS=5`, `STORY_MAX_TOTAL_DURATION=60.0` constants
- `instagram_post.py`: `create_story_container()` and `post_story()` (video upload via litterbox → `media_type=STORIES` container → publish)
- `models.py` + migration 0015: `instagram_story_id` field on `WeeklyPlaylist`
- `generate_weekly_playlist_video.py`: `--format story` branch with token auth, generation, post, persistence
- `hakoake-gen-video.sh`: new story step
- `pyproject.toml`: ruff S105/S106/S107 ignore for test files

## Test plan
- [ ] Run `uv run python manage.py test houses.tests.test_generate_weekly_playlist_video_command.TestGenerateWeeklyPlaylistVideoStoryFormat` — 3 tests should pass
- [ ] Apply migration: `uv run python manage.py migrate`
- [ ] Test post: `uv run python manage.py generate_weekly_playlist_video <playlist_id> --format story --skip-update-playlist` to generate video without posting
- [ ] Verify video duration ≤55s
- [ ] Live test post to Instagram: `uv run python manage.py generate_weekly_playlist_video <playlist_id> --format story`

Closes #92