### PR TITLE
fix(playlist-intro): clarify playlist song is a sample, not performed setlist

### DIFF
--- a/malcom/houses/functions.py
+++ b/malcom/houses/functions.py
@@ -472,8 +472,11 @@ def _generate_introduction_text(  # noqa: C901, PLR0912, PLR0915
     entry_count = len(playlist_entries)
 
     user_query = [
-        f"For {period_label} write an introduction to selected artists below, describing where and when they will play."
-        "ALWAYS mention the date and day of the week when introduction where/when the artists play."
+        f"For {period_label} write an introduction to selected artists below, "
+        "describing where and when they will perform live."
+        "ALWAYS mention the date and day of the week when introducing where/when the artists perform live."
+        "IMPORTANT: The listed song is a SAMPLE only — do NOT say or imply the song will be performed. "
+        "The artist may play a completely different setlist."
         "The site's description is as follows (DO NOT INCLUDE it in the result response, but consider it for flavor):\n"
         "Can't see the artist for your seat? Ditch the arenas and stadiums.\n"
         'Your new favorite band is playing in dark cramped basement bars, or "Live Houses".\n'

--- a/malcom/houses/templates/PLAYLIST_INTRO_PROMPT.md
+++ b/malcom/houses/templates/PLAYLIST_INTRO_PROMPT.md
@@ -76,7 +76,7 @@ Describe the selection criteria:
   - Promises about specific sounds (viewers will hear for themselves)
   - Repetitive phrases across performer sections (e.g., repeating "don't miss out", "first time", etc.)
   - Words: 'excited', 'exciting', 'grab', 'underground', 'vibrant'
-  - mentioning the playlist song will be performed (it may not be performed)
+  - Stating or implying that the playlist sample song will be performed live — the selected song is a SAMPLE only; the artist may perform a completely different setlist. NEVER say a song "will be performed" or "will play" in reference to the playlist song.
   - DO NOT pronounce the site (HAKKO-AKKEI/HAKOAKE), use 'we' instead.
 
 ### What Makes a Great Introduction


### PR DESCRIPTION
## Summary

Fixes the playlist intro voice over mistakenly implying the sample song will be performed live.

- Strengthened the constraint in `PLAYLIST_INTRO_PROMPT.md` — previously weak/ambiguous wording buried in the Avoid list; now explicitly says NEVER use 'will be performed' for the playlist song
- Updated the user query in `functions.py` to add an IMPORTANT note: the listed song is a SAMPLE only, the artist may play a completely different setlist

Closes #99

## Test plan
- [ ] Regenerate a monthly playlist intro and verify the output does not say the sample song 'will be performed'