### PR TITLE
feat(threads): post weekly and monthly playlist announcements to Threads

### DIFF
--- a/malcom/commons/tests/test_threads_utils.py
+++ b/malcom/commons/tests/test_threads_utils.py
@@ -1,0 +1,123 @@
+"""Tests for Threads post-building helpers and create_thread_post."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from commons.threads_utils import (
+    THREADS_MAX_CHARS,
+    _build_monthly_thread_text,
+    _build_weekly_thread_text,
+    _truncate_to_threads_limit,
+    create_thread_post,
+)
+
+
+class TestTruncateToThreadsLimit(TestCase):
+    def test_short_text_unchanged(self) -> None:
+        result = _truncate_to_threads_limit("Hello", "https://example.com")
+        self.assertEqual(result, "Hello\nhttps://example.com")
+        self.assertLessEqual(len(result), THREADS_MAX_CHARS)
+
+    def test_url_always_present_after_truncation(self) -> None:
+        url = "https://www.youtube.com/playlist?list=PLtest123"
+        long_lines = "\n".join(f"{i}. 2026-01-0{i % 9 + 1} (Mon) BandName{i} @ Venue{i}" for i in range(1, 20))
+        result = _truncate_to_threads_limit(long_lines, url)
+        self.assertLessEqual(len(result), THREADS_MAX_CHARS)
+        self.assertIn(url, result)
+
+    def test_truncation_ends_with_ellipsis_before_url(self) -> None:
+        url = "https://www.youtube.com/playlist?list=PLtest123"
+        long_text = "A" * 400 + "\n" + "B" * 200
+        result = _truncate_to_threads_limit(long_text, url)
+        self.assertLessEqual(len(result), THREADS_MAX_CHARS)
+        self.assertIn("…", result)
+        self.assertTrue(result.endswith(url))
+
+    def test_exactly_at_limit_not_truncated(self) -> None:
+        url = "https://x.com/p"
+        # Build text so total is exactly THREADS_MAX_CHARS
+        overhead = len(f"\n{url}")
+        text = "x" * (THREADS_MAX_CHARS - overhead)
+        result = _truncate_to_threads_limit(text, url)
+        self.assertEqual(len(result), THREADS_MAX_CHARS)
+        self.assertNotIn("…", result)
+
+
+class _FakePlaylist:
+    """Minimal duck-typed playlist for text-building tests."""
+
+    def __init__(self, playlist_date: date, playlist_id: str, playlist_url: str = "") -> None:
+        self.date = playlist_date
+        self.youtube_playlist_id = playlist_id
+        self.youtube_playlist_url = playlist_url
+
+
+class TestBuildWeeklyThreadText(TestCase):
+    def test_includes_url_from_youtube_playlist_url(self) -> None:
+        playlist = _FakePlaylist(date(2026, 3, 31), "PLtest", "https://www.youtube.com/playlist?list=PLtest")
+        lineup_lines = ["1. 2026-03-31 (Tue) TestBand @ Shibuya Club"]
+        result = _build_weekly_thread_text(playlist, lineup_lines)
+        self.assertIn("https://www.youtube.com/playlist?list=PLtest", result)
+
+    def test_falls_back_to_constructed_url_when_no_playlist_url(self) -> None:
+        playlist = _FakePlaylist(date(2026, 3, 31), "PLfallback", "")
+        lineup_lines = ["1. 2026-03-31 (Tue) TestBand @ Shibuya Club"]
+        result = _build_weekly_thread_text(playlist, lineup_lines)
+        self.assertIn("PLfallback", result)
+
+    def test_within_character_limit(self) -> None:
+        playlist = _FakePlaylist(date(2026, 3, 31), "PLtest", "https://www.youtube.com/playlist?list=PLtest")
+        lineup_lines = [f"{i}. 2026-03-31 (Tue) Band{i:02d} @ Venue{i:02d}" for i in range(1, 20)]
+        result = _build_weekly_thread_text(playlist, lineup_lines)
+        self.assertLessEqual(len(result), THREADS_MAX_CHARS)
+
+
+class TestBuildMonthlyThreadText(TestCase):
+    def test_includes_month_in_text(self) -> None:
+        playlist = _FakePlaylist(date(2026, 4, 1), "PLmonth", "https://www.youtube.com/playlist?list=PLmonth")
+        lineup_lines = ["1. 2026-04-10 (Fri) TestBand @ Shinjuku Club"]
+        result = _build_monthly_thread_text(playlist, lineup_lines)
+        self.assertIn("April 2026", result)
+        self.assertIn("https://www.youtube.com/playlist?list=PLmonth", result)
+
+    def test_within_character_limit(self) -> None:
+        playlist = _FakePlaylist(date(2026, 4, 1), "PLmonth", "https://www.youtube.com/playlist?list=PLmonth")
+        lineup_lines = [f"{i}. 2026-04-{i:02d} (Mon) Band{i:02d} @ Venue{i:02d}" for i in range(1, 20)]
+        result = _build_monthly_thread_text(playlist, lineup_lines)
+        self.assertLessEqual(len(result), THREADS_MAX_CHARS)
+
+
+class TestCreateThreadPost(TestCase):
+    @patch("commons.threads_utils.requests.post")
+    def test_two_step_publish_returns_thread_id(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = [
+            MagicMock(json=lambda: {"id": "container123"}, raise_for_status=lambda: None),
+            MagicMock(json=lambda: {"id": "thread456"}, raise_for_status=lambda: None),
+        ]
+        result = create_thread_post("user1", "tok", "Hello Threads")
+        self.assertEqual(result, "thread456")
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("commons.threads_utils.requests.post")
+    def test_create_step_uses_text_media_type(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = [
+            MagicMock(json=lambda: {"id": "c1"}, raise_for_status=lambda: None),
+            MagicMock(json=lambda: {"id": "t1"}, raise_for_status=lambda: None),
+        ]
+        create_thread_post("user1", "tok", "Test post")
+        first_call_params = mock_post.call_args_list[0].kwargs.get("params", {})
+        self.assertEqual(first_call_params.get("media_type"), "TEXT")
+
+    @patch("commons.threads_utils.requests.post")
+    def test_publish_step_sends_container_id(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = [
+            MagicMock(json=lambda: {"id": "container99"}, raise_for_status=lambda: None),
+            MagicMock(json=lambda: {"id": "thread99"}, raise_for_status=lambda: None),
+        ]
+        create_thread_post("user1", "tok", "Test")
+        second_call_params = mock_post.call_args_list[1].kwargs.get("params", {})
+        self.assertEqual(second_call_params.get("creation_id"), "container99")

--- a/malcom/commons/threads_utils.py
+++ b/malcom/commons/threads_utils.py
@@ -228,3 +228,78 @@ def get_threads_token(cert_file: Path, key_file: Path, token_cache_file: Path) -
     _save_token(token, token_cache_file)
     logger.info(f"Threads OAuth complete -- user_id={user_id}")
     return token
+
+
+THREADS_MAX_CHARS = 500
+
+
+def _truncate_to_threads_limit(description: str, url: str) -> str:
+    """Truncate description at a line boundary so the full URL fits within THREADS_MAX_CHARS."""
+    full = f"{description}\n{url}"
+    if len(full) <= THREADS_MAX_CHARS:
+        return full
+    budget = THREADS_MAX_CHARS - len(f"…\n{url}")
+    lines = description.splitlines()
+    kept: list[str] = []
+    total = 0
+    for line in lines:
+        needed = len(line) + (1 if kept else 0)
+        if total + needed > budget:
+            break
+        kept.append(line)
+        total += needed
+    return "\n".join(kept) + f"…\n{url}"
+
+
+def _build_weekly_thread_text(playlist: "object", lineup_lines: list[str]) -> str:
+    """Build the Threads post text for a weekly playlist."""
+    from houses.formatting import build_playlist_description  # noqa: PLC0415
+
+    lineup_str = "\n".join(lineup_lines)
+    period_text = f"week of {playlist.date.strftime('%Y-%m-%d')}"  # type: ignore[attr-defined]
+    description = build_playlist_description(period_text, lineup_str)
+    url = playlist.youtube_playlist_url or f"https://www.youtube.com/playlist?list={playlist.youtube_playlist_id}"  # type: ignore[attr-defined]
+    return _truncate_to_threads_limit(description, url)
+
+
+def _build_monthly_thread_text(playlist: "object", lineup_lines: list[str]) -> str:
+    """Build the Threads post text for a monthly playlist."""
+    from houses.formatting import build_playlist_description  # noqa: PLC0415
+
+    lineup_str = "\n".join(lineup_lines)
+    period_text = playlist.date.strftime("%B %Y")  # type: ignore[attr-defined]
+    description = build_playlist_description(period_text, lineup_str)
+    url = playlist.youtube_playlist_url or f"https://www.youtube.com/playlist?list={playlist.youtube_playlist_id}"  # type: ignore[attr-defined]
+    return _truncate_to_threads_limit(description, url)
+
+
+def create_thread_post(user_id: str, access_token: str, text: str) -> str:
+    """Publish a text-only Threads post via the two-step create-container/publish flow.
+
+    Returns the published thread ID.
+    """
+    create_resp = requests.post(
+        f"{THREADS_API_BASE}/{user_id}/threads",
+        params={
+            "media_type": "TEXT",
+            "text": text,
+            "access_token": access_token,
+        },
+        timeout=30,
+    )
+    create_resp.raise_for_status()
+    container_id = create_resp.json()["id"]
+    logger.info(f"Threads container created: {container_id}")
+
+    publish_resp = requests.post(
+        f"{THREADS_API_BASE}/{user_id}/threads_publish",
+        params={
+            "creation_id": container_id,
+            "access_token": access_token,
+        },
+        timeout=30,
+    )
+    publish_resp.raise_for_status()
+    thread_id = publish_resp.json()["id"]
+    logger.info(f"Threads post published: {thread_id}")
+    return thread_id

--- a/malcom/houses/management/commands/post_monthly_playlist_threads.py
+++ b/malcom/houses/management/commands/post_monthly_playlist_threads.py
@@ -1,0 +1,84 @@
+"""Post a monthly playlist announcement to Threads.
+
+Posts the playlist description and YouTube link as a text-based Threads post.
+Text is truncated at a performer-line boundary if the total exceeds the
+500-character Threads limit.
+
+Usage:
+    uv run python manage.py post_monthly_playlist_threads 2026-05
+    uv run python manage.py post_monthly_playlist_threads 2026-05 --dry-run
+"""
+
+from __future__ import annotations
+
+import logging
+
+from commons.functions import get_month_end, parse_month
+from commons.threads_utils import _build_monthly_thread_text, create_thread_post, get_threads_token
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandParser
+from houses.formatting import build_lineup_lines
+from houses.models import MonthlyPlaylist, MonthlyPlaylistEntry
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Post a monthly playlist announcement to Threads"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "target_month",
+            type=str,
+            help="Target month in YYYY-MM format",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Log post text without publishing to Threads",
+        )
+
+    def handle(self, *args: object, **options: object) -> None:
+        target_month_str: str = options["target_month"]  # type: ignore[assignment]
+        dry_run: bool = options["dry_run"]  # type: ignore[assignment]
+
+        try:
+            target_date = parse_month(target_month_str)
+        except ValueError as exc:
+            self.stderr.write(self.style.ERROR(str(exc)))
+            return
+
+        try:
+            playlist = MonthlyPlaylist.objects.get(date=target_date)
+        except MonthlyPlaylist.DoesNotExist:
+            self.stderr.write(self.style.ERROR(f"MonthlyPlaylist for {target_month_str} not found"))
+            return
+
+        entries = list(
+            MonthlyPlaylistEntry.objects.filter(playlist=playlist)
+            .order_by("position")
+            .select_related("song__performer")
+        )
+        if not entries:
+            self.stderr.write(self.style.ERROR("Playlist has no entries"))
+            return
+
+        month_start = playlist.date
+        month_end = get_month_end(month_start)
+        performer_song_pairs = [(e.song.performer, e.song) for e in entries]
+        lineup_lines = build_lineup_lines(performer_song_pairs, month_start, month_end)
+
+        post_text = _build_monthly_thread_text(playlist, lineup_lines)
+        self.stdout.write(f"Post text ({len(post_text)} chars):\n{post_text}")
+
+        if dry_run:
+            self.stdout.write(self.style.SUCCESS("Dry run — not published"))
+            return
+
+        cert_file = settings.OAUTH_LOCALHOST_CERT
+        key_file = settings.OAUTH_LOCALHOST_KEY
+        token_cache = cert_file.parent / "threads_token.json"
+        token = get_threads_token(cert_file, key_file, token_cache)
+
+        thread_id = create_thread_post(token.user_id, token.access_token, post_text)
+        self.stdout.write(self.style.SUCCESS(f"Published to Threads: thread_id={thread_id}"))

--- a/malcom/houses/management/commands/post_weekly_playlist_threads.py
+++ b/malcom/houses/management/commands/post_weekly_playlist_threads.py
@@ -1,0 +1,77 @@
+"""Post a weekly playlist announcement to Threads.
+
+Posts the playlist description and YouTube link as a text-based Threads post.
+The post text mirrors the YouTube playlist description (build_playlist_description)
+with the YouTube URL appended. Text is truncated at a performer-line boundary if
+the total exceeds the 500-character Threads limit.
+
+Usage:
+    uv run python manage.py post_weekly_playlist_threads <playlist_id>
+    uv run python manage.py post_weekly_playlist_threads <playlist_id> --dry-run
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from commons.threads_utils import _build_weekly_thread_text, create_thread_post, get_threads_token
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandParser
+from houses.formatting import build_lineup_lines
+from houses.models import WeeklyPlaylist, WeeklyPlaylistEntry
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Post a weekly playlist announcement to Threads"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "playlist_id",
+            type=int,
+            help="WeeklyPlaylist pk",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Log post text without publishing to Threads",
+        )
+
+    def handle(self, *args: object, **options: object) -> None:
+        playlist_id: int = options["playlist_id"]  # type: ignore[assignment]
+        dry_run: bool = options["dry_run"]  # type: ignore[assignment]
+
+        try:
+            playlist = WeeklyPlaylist.objects.get(id=playlist_id)
+        except WeeklyPlaylist.DoesNotExist:
+            self.stderr.write(self.style.ERROR(f"WeeklyPlaylist id={playlist_id} not found"))
+            return
+
+        entries = list(
+            WeeklyPlaylistEntry.objects.filter(playlist=playlist).order_by("position").select_related("song__performer")
+        )
+        if not entries:
+            self.stderr.write(self.style.ERROR("Playlist has no entries"))
+            return
+
+        week_start = playlist.date
+        week_end = week_start + timedelta(days=7)
+        performer_song_pairs = [(e.song.performer, e.song) for e in entries]
+        lineup_lines = build_lineup_lines(performer_song_pairs, week_start, week_end)
+
+        post_text = _build_weekly_thread_text(playlist, lineup_lines)
+        self.stdout.write(f"Post text ({len(post_text)} chars):\n{post_text}")
+
+        if dry_run:
+            self.stdout.write(self.style.SUCCESS("Dry run — not published"))
+            return
+
+        cert_file = settings.OAUTH_LOCALHOST_CERT
+        key_file = settings.OAUTH_LOCALHOST_KEY
+        token_cache = cert_file.parent / "threads_token.json"
+        token = get_threads_token(cert_file, key_file, token_cache)
+
+        thread_id = create_thread_post(token.user_id, token.access_token, post_text)
+        self.stdout.write(self.style.SUCCESS(f"Published to Threads: thread_id={thread_id}"))


### PR DESCRIPTION
Closes #11

## Summary

- Adds `create_thread_post()`, `_build_weekly_thread_text()`, `_build_monthly_thread_text()`, and `_truncate_to_threads_limit()` to `commons/threads_utils.py`
- Adds `post_weekly_playlist_threads <playlist_id> [--dry-run]` management command
- Adds `post_monthly_playlist_threads <target_month> [--dry-run]` management command
- Truncation logic keeps playlist URL always visible when text would exceed the 500-char Threads limit

## Implementation notes

- Reuses `build_playlist_description()` from `houses/formatting.py` (same output as YouTube/Instagram captions)
- Token loaded via existing `get_threads_token()` from `commons/threads_utils.py`
- Two-step Threads API publish flow: `POST /{user_id}/threads` → `POST /{user_id}/threads_publish`
- `user_id` sourced from OAuth token cache (avoids settings drift)

## Test plan

- [ ] 12 unit tests passing (`uv run poe test`) — truncation, URL presence, mocked HTTP publish flow
- [ ] `uv run python manage.py post_weekly_playlist_threads <id> --dry-run` — review output text and char count
- [ ] `uv run python manage.py post_monthly_playlist_threads 2026-05 --dry-run` — review output text and char count
- [ ] Live publish to Threads sandbox/account for final verification