### PR TITLE
fix(scripts): add FORCE_DATE override and duplicate-post guard to hakoake-gen-video.sh

### DIFF
--- a/malcom/houses/management/commands/list_weekly_playlist.py
+++ b/malcom/houses/management/commands/list_weekly_playlist.py
@@ -83,6 +83,7 @@ class Command(BaseCommand):
                         "date": playlist.date.strftime("%Y-%m-%d"),
                         "youtube_playlist_id": playlist.youtube_playlist_id,
                         "youtube_playlist_url": playlist.youtube_playlist_url,
+                        "instagram_post_id": playlist.instagram_post_id or None,
                     }
                 )
             )

--- a/scripts/hakoake-gen-video.sh
+++ b/scripts/hakoake-gen-video.sh
@@ -6,6 +6,8 @@
 # 3. Generates the playlist video
 # 4. Generates and uploads the YouTube Shorts version
 # 5. Posts the Instagram carousel announcement
+#
+# Manual recovery: FORCE_DATE=2026-06-08 bash scripts/hakoake-gen-video.sh
 set -euo pipefail
 
 export PATH="/home/monkut/.local/bin:$PATH"
@@ -14,8 +16,12 @@ HAKOAKE_DIR="$HOME/projects/hakoake-backend/malcom"
 LOG_DIR="$HOME/projects/hakoake-backend/logs"
 mkdir -p "$LOG_DIR"
 
-# Get next Monday's date in JST (today + 7 days) — target the upcoming week
-MONDAY=$(TZ=Asia/Tokyo date -d '+7 days' +%Y-%m-%d)
+# Allow manual date override for recovery runs; default to next Monday (+7 days in JST).
+if [[ -n "${FORCE_DATE:-}" ]]; then
+    MONDAY="$FORCE_DATE"
+else
+    MONDAY=$(TZ=Asia/Tokyo date -d '+7 days' +%Y-%m-%d)
+fi
 LOGFILE="$LOG_DIR/hakoake-gen-video-${MONDAY}.log"
 
 # Tee all output (stdout + stderr) to a dated log file
@@ -27,6 +33,15 @@ uv run python manage.py create_weekly_playlist "$MONDAY"
 
 echo "Looking up playlist DB id for ${MONDAY}..."
 playlist_db_id=$(uv run python manage.py list_weekly_playlist "$MONDAY" --json | jq -r '.id')
+
+# Guard: skip the expensive video generation and Instagram post if this playlist was
+# already announced. post_weekly_playlist has its own idempotency guard (instagram_post_id)
+# but checking here avoids re-running the slow video-generation steps unnecessarily.
+already_posted=$(uv run python manage.py list_weekly_playlist "$MONDAY" --json | jq -r '.instagram_post_id // empty')
+if [[ -n "$already_posted" ]]; then
+    echo "Playlist ${playlist_db_id} (${MONDAY}) already posted to Instagram (post_id=${already_posted}); skipping."
+    exit 0
+fi
 
 echo "Generating weekly playlist video for playlist id=${playlist_db_id}..."
 uv run python manage.py generate_weekly_playlist_video "$playlist_db_id"


### PR DESCRIPTION
## Summary

- Adds `FORCE_DATE` env var to `hakoake-gen-video.sh` for manual recovery runs (e.g. `FORCE_DATE=2026-06-08 bash scripts/hakoake-gen-video.sh`) without needing to edit the script.
- Adds an early-exit guard that reads `instagram_post_id` from the resolved playlist before running the expensive video-generation pipeline — prevents re-uploading to YouTube and re-posting to Instagram if the script is re-run.
- Extends `list_weekly_playlist --json` output to include `instagram_post_id` so the shell guard can read it via `jq`.

Closes #103

## Test plan

- [x] Manually ran recovery for week-of-2026-06-08 using the individual management commands (this PR adds `FORCE_DATE` so future recoveries can use the script directly)
- [x] `post_weekly_playlist --playlist-id=13` posted successfully to Instagram (post_id=18076192793283781)
- [x] `list_weekly_playlist 2026-06-08 --json` now includes `instagram_post_id` field
- [x] Pre-commit hooks (ruff, ruff-format) pass