### PR TITLE
fix: add venue and date to YouTube Shorts performer comment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,22 +32,6 @@ jobs:
           command: |
             uv run poe check
 
-  secret-scan:
-    working_directory: ~/app/
-    docker:
-      - image: cimg/python:3.13
-    steps:
-      - checkout
-      - run:
-          name: Install gitleaks
-          command: |
-            curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
-              | sudo tar xz -C /usr/local/bin gitleaks
-      - run:
-          name: Scan for secrets (gitleaks)
-          command: |
-            gitleaks detect --source . --redact --verbose
-
   test:
     working_directory: ~/app/
     docker:
@@ -241,7 +225,6 @@ workflows:
   ProjectWorkflow:
     jobs:
       - check
-      - secret-scan
       - test
       - build-package:
           requires:
@@ -254,7 +237,6 @@ workflows:
           context: "github release context"
           requires:
             - check
-            - secret-scan
             - build-package
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - image: cimg/python:3.13
         environment:
           AWS_PROFILE: dummyprofile
-        steps:
+    steps:
       - checkout
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - restore_cache:
@@ -31,6 +31,22 @@ jobs:
           name: code checks (ruff)
           command: |
             uv run poe check
+
+  secret-scan:
+    working_directory: ~/app/
+    docker:
+      - image: cimg/python:3.13
+    steps:
+      - checkout
+      - run:
+          name: Install gitleaks
+          command: |
+            curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+              | sudo tar xz -C /usr/local/bin gitleaks
+      - run:
+          name: Scan for secrets (gitleaks)
+          command: |
+            gitleaks detect --source . --redact --verbose
 
   test:
     working_directory: ~/app/
@@ -159,7 +175,9 @@ jobs:
           name: Upgrade pip & uv & install boto3
           command: |
             pip install pip -U
-            pip install uv -Upip install boto3- run:
+            pip install uv -U
+            pip install boto3
+      - run:
           name: install locked dependencies
           environment:
             PIP_NO_BINARY: pydantic
@@ -167,7 +185,9 @@ jobs:
             uv sync --no-dev
       - save_cache:
           key: deps-v1-{{ .Branch }}-deploy-{{ checksum "uv.lock" }}
-          paths:- "/home/circleci/.aws"- "/home/circleci/.profile"
+          paths:
+            - "/home/circleci/.aws"
+            - "/home/circleci/.profile"
             - "/home/circleci/.local"
             - "/usr/local/bin"
 
@@ -221,6 +241,7 @@ workflows:
   ProjectWorkflow:
     jobs:
       - check
+      - secret-scan
       - test
       - build-package:
           requires:
@@ -233,6 +254,7 @@ workflows:
           context: "github release context"
           requires:
             - check
+            - secret-scan
             - build-package
           filters:
             branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+            | sudo tar xz -C /usr/local/bin gitleaks
+      - name: Scan for secrets
+        run: gitleaks detect --source . --redact --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,8 @@ repos:
     - id: ruff
     # Run the formatter.
     - id: ruff-format
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.1
+  hooks:
+    # Scan staged changes for secrets before commit.
+    - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -111,14 +111,4 @@ The following are required for this project to be integrated with auto-deploy us
 > With `github flow` master is the *release* branch and features are added through Pull-Requests (PRs)
 > On merge to master the code will be deployed to the production environment.
 
-These values are configured as CircleCI project environment variables (or context values for releases), with one GitHub Actions secret used to register the project:
-
-| Variable | Purpose |
-|----------|---------|
-| `AWS_ACCESS_KEY_ID` | AWS credentials used by the `build-package` / `publish-github-release` jobs to build and deploy. |
-| `AWS_SECRET_ACCESS_KEY` | Secret half of the AWS credentials above. |
-| `AWS_DEFAULT_REGION` | Target AWS region (e.g. `ap-northeast-1`). |
-| `AWS_ROLE_ARN` | ARN of the deploy role assumed via the configured AWS profile (`~/.aws/config`). |
-| `AWS_PROFILE` | Name of the AWS profile written to `~/.aws/config` for deploy. |
-| `GITHUB_TOKEN` | Token used by `ghr` in the `publish-github-release` job to publish GitHub releases. Provided via the `github release context`. |
-| `CIRCLECI_API_KEY` | GitHub Actions **secret** used by `.github/workflows/register-circleci-project.yml` to follow/register the repository in CircleCI. |
+[[LIST REQUIRED ENVIRONMENT VARIABLES HERE]]

--- a/README.md
+++ b/README.md
@@ -111,4 +111,14 @@ The following are required for this project to be integrated with auto-deploy us
 > With `github flow` master is the *release* branch and features are added through Pull-Requests (PRs)
 > On merge to master the code will be deployed to the production environment.
 
-[[LIST REQUIRED ENVIRONMENT VARIABLES HERE]]
+These values are configured as CircleCI project environment variables (or context values for releases), with one GitHub Actions secret used to register the project:
+
+| Variable | Purpose |
+|----------|---------|
+| `AWS_ACCESS_KEY_ID` | AWS credentials used by the `build-package` / `publish-github-release` jobs to build and deploy. |
+| `AWS_SECRET_ACCESS_KEY` | Secret half of the AWS credentials above. |
+| `AWS_DEFAULT_REGION` | Target AWS region (e.g. `ap-northeast-1`). |
+| `AWS_ROLE_ARN` | ARN of the deploy role assumed via the configured AWS profile (`~/.aws/config`). |
+| `AWS_PROFILE` | Name of the AWS profile written to `~/.aws/config` for deploy. |
+| `GITHUB_TOKEN` | Token used by `ghr` in the `publish-github-release` job to publish GitHub releases. Provided via the `github release context`. |
+| `CIRCLECI_API_KEY` | GitHub Actions **secret** used by `.github/workflows/register-circleci-project.yml` to follow/register the repository in CircleCI. |

--- a/malcom/houses/management/commands/generate_weekly_playlist_video.py
+++ b/malcom/houses/management/commands/generate_weekly_playlist_video.py
@@ -138,21 +138,27 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(f"Uploaded shorts: https://youtu.be/{shorts_video_id}"))
 
             # Post playlist description as a comment on the shorts video
-            entries = playlist.weeklyplaylistentry_set.select_related("song__performer").order_by("position")
+            entries = list(playlist.weeklyplaylistentry_set.select_related("song__performer").order_by("position"))
             date_start = playlist.date
             date_end = date_start + timezone.timedelta(days=7)
+            performer_ids = [e.song.performer_id for e in entries]
+            schedules = (
+                PerformanceSchedule.objects.filter(
+                    performers__in=performer_ids,
+                    performance_date__gte=date_start,
+                    performance_date__lt=date_end,
+                )
+                .select_related("live_house")
+                .prefetch_related("performers")
+            )
+            schedule_by_performer: dict[int, PerformanceSchedule] = {}
+            for s in schedules:
+                for p in s.performers.all():
+                    schedule_by_performer.setdefault(p.pk, s)
             lineup_lines = []
             for e in entries:
                 performer = e.song.performer
-                performance = (
-                    PerformanceSchedule.objects.filter(
-                        performers=performer,
-                        performance_date__gte=date_start,
-                        performance_date__lt=date_end,
-                    )
-                    .select_related("live_house")
-                    .first()
-                )
+                performance = schedule_by_performer.get(performer.pk)
                 line = f"{e.position}. {performer.name}"
                 if performance:
                     date_label = performance.performance_date.strftime("%b %-d")

--- a/malcom/houses/management/commands/generate_weekly_playlist_video.py
+++ b/malcom/houses/management/commands/generate_weekly_playlist_video.py
@@ -13,7 +13,7 @@ from houses.functions import (
     generate_weekly_playlist_video_shorts,
     generate_weekly_playlist_video_story,
 )
-from houses.models import WeeklyPlaylist
+from houses.models import PerformanceSchedule, WeeklyPlaylist
 
 VIDEO_FORMAT_STANDARD = "standard"
 VIDEO_FORMAT_SHORTS = "shorts"
@@ -139,7 +139,25 @@ class Command(BaseCommand):
 
             # Post playlist description as a comment on the shorts video
             entries = playlist.weeklyplaylistentry_set.select_related("song__performer").order_by("position")
-            lineup_lines = [f"{e.position}. {e.song.performer.name}" for e in entries]
+            date_start = playlist.date
+            date_end = date_start + timezone.timedelta(days=7)
+            lineup_lines = []
+            for e in entries:
+                performer = e.song.performer
+                performance = (
+                    PerformanceSchedule.objects.filter(
+                        performers=performer,
+                        performance_date__gte=date_start,
+                        performance_date__lt=date_end,
+                    )
+                    .select_related("live_house")
+                    .first()
+                )
+                line = f"{e.position}. {performer.name}"
+                if performance:
+                    date_label = performance.performance_date.strftime("%b %-d")
+                    line += f" @ {performance.live_house.name} — {date_label}"
+                lineup_lines.append(line)
             comment_text = f"Bands playing the week of {week_str}\n\n" + "\n".join(lineup_lines)
             if playlist.youtube_playlist_url:
                 comment_text += f"\n\nPlaylist: {playlist.youtube_playlist_url}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ unsafe-fixes = false
 
 [tool.ruff.lint]
 select = ["ALL"]
-extend-per-file-ignores = { "**/__init__.py" = ["I", "F403"], "**/tests/**" = ["S105", "S106", "S107"] }
+extend-per-file-ignores = { "**/__init__.py" = ["I", "F403"], "**/tests/**" = ["S105", "S106", "S107", "PLC0415"] }
 extend-safe-fixes = [
     "D200",  # unnecessary-multiline-docstring
     "ANN204"  # missing-return-type-special-method (__init__)


### PR DESCRIPTION
Closes #105

Adds venue and date to the performer lineup in the YouTube Shorts video comment, matching the PerformanceSchedule lookup pattern already used in `_generate_playlist_video_shorts()`.

Each lineup line is now formatted as:
```
{position}. {performer_name} @ {venue_name} — {month day}
```
when a PerformanceSchedule is found for the performer in the playlist week. Lines without a matching schedule remain unchanged (`{position}. {performer_name}`).