### PR TITLE
fix: assert a CJK-capable font resolves so missing Noto CJK fails loudly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Python: 3.13
     uv sync
     ```
 
-3. Install Playwright browsers (required for JavaScript-enabled web scraping):
+3. Install the Noto CJK system fonts (required for slide rendering — without them Japanese text in generated slides renders as tofu `□`; startup logs a CRITICAL message if no CJK-capable font is found):
+
+    ```bash
+    sudo apt install fonts-noto-cjk
+    ```
+
+4. Install Playwright browsers (required for JavaScript-enabled web scraping):
 
     ```bash
     uv run playwright install

--- a/malcom/commons/apps.py
+++ b/malcom/commons/apps.py
@@ -1,5 +1,11 @@
 from django.apps import AppConfig
 
+from commons.design import verify_cjk_font_available
+
 
 class CommonsConfig(AppConfig):
     name = "commons"
+
+    def ready(self) -> None:
+        """Fail loudly at startup if no CJK-capable font is installed."""
+        verify_cjk_font_available()

--- a/malcom/commons/design.py
+++ b/malcom/commons/design.py
@@ -105,6 +105,59 @@ def body_font(size: int, *, bold: bool = False) -> ImageFont.FreeTypeFont | Imag
     return _load_font(_BODY_BOLD_FALLBACKS if bold else _BODY_REGULAR_FALLBACKS, size)
 
 
+# --- CJK availability check ---
+# The final fallback in every chain (DejaVu) is Latin-only, so if every CJK face
+# is missing the chains still "succeed" and Japanese text silently renders as
+# tofu (□). verify_cjk_font_available makes that failure loud at startup.
+_CJK_PROBE_GLYPH = "あ"  # hiragana 'a' — any Japanese-capable face must map it
+_UNMAPPED_PROBE_GLYPH = "￾"  # Unicode noncharacter — no font maps it, always renders .notdef
+_CJK_PROBE_SIZE = 32
+
+
+def _render_probe_glyph(font: ImageFont.FreeTypeFont | ImageFont.ImageFont, char: str) -> bytes:
+    """Render a single glyph onto a fixed canvas and return the raw pixel bytes."""
+    canvas = Image.new("L", (_CJK_PROBE_SIZE * 2, _CJK_PROBE_SIZE * 2), 0)
+    ImageDraw.Draw(canvas).text((4, 4), char, font=font, fill=255)
+    return canvas.tobytes()
+
+
+def _renders_cjk(font: ImageFont.FreeTypeFont | ImageFont.ImageFont) -> bool:
+    """Return True if the font draws the CJK probe glyph as a real glyph, not .notdef tofu.
+
+    A font without a glyph for a codepoint renders its .notdef shape instead.
+    U+FFFE is a noncharacter no font maps, so its rendering IS the .notdef shape -
+    if the CJK probe glyph renders identically, the font cannot draw Japanese.
+    """
+    try:
+        return _render_probe_glyph(font, _CJK_PROBE_GLYPH) != _render_probe_glyph(font, _UNMAPPED_PROBE_GLYPH)
+    except OSError:
+        return False
+
+
+def verify_cjk_font_available() -> bool:
+    """Verify every font fallback chain resolves to a CJK-capable face.
+
+    Logs CRITICAL naming the failing chain(s) and returns False when Japanese
+    text would render as tofu - e.g. the ``fonts-noto-cjk`` system package is
+    not installed. Called from ``CommonsConfig.ready()`` so a broken font
+    install is loud at startup instead of discovered in published slides.
+    """
+    chains = (
+        ("display", _DISPLAY_FALLBACKS),
+        ("body-bold", _BODY_BOLD_FALLBACKS),
+        ("body-regular", _BODY_REGULAR_FALLBACKS),
+    )
+    failed = [name for name, chain in chains if not _renders_cjk(_load_font(chain, _CJK_PROBE_SIZE))]
+    if failed:
+        logger.critical(
+            "No CJK-capable font resolved for font chain(s): %s - "
+            "Japanese text will render as tofu. Install the 'fonts-noto-cjk' system package.",
+            ", ".join(failed),
+        )
+        return False
+    return True
+
+
 # --- Layout helpers ---
 
 

--- a/malcom/commons/tests/test_design.py
+++ b/malcom/commons/tests/test_design.py
@@ -7,6 +7,9 @@ both the Instagram carousel and the playlist video pipelines.
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest import mock
+
 from django.test import TestCase
 from PIL import Image, ImageDraw
 
@@ -23,6 +26,7 @@ from commons.design import (
     draw_torn_edge,
     paper_grain,
     scale_to_fill,
+    verify_cjk_font_available,
     wrap_text,
 )
 
@@ -116,3 +120,38 @@ class TestLayoutHelpers(TestCase):
         draw = ImageDraw.Draw(img)
         for anchor in ("lt", "rt", "lb", "rb"):
             draw_corner_wordmark(draw, (200, 200), anchor=anchor)
+
+
+class TestVerifyCjkFontAvailable(TestCase):
+    DEJAVU_ONLY = ((Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"), None),)
+    ALL_MISSING = ((Path("/nonexistent/NoSuchFont-Bold.ttc"), 0),)
+
+    def test_passes_in_normal_environment(self) -> None:
+        """With Noto CJK / Shippori installed (dev and CI baseline) the check passes."""
+        self.assertTrue(verify_cjk_font_available())
+
+    def test_fails_when_only_latin_fallback_resolves(self) -> None:
+        """If every CJK face is missing and only DejaVu resolves, the check logs CRITICAL.
+
+        This is the silent-tofu scenario this check exists for: the fallback
+        chain still "succeeds" but Japanese text renders as .notdef boxes.
+        """
+        with (
+            mock.patch("commons.design._DISPLAY_FALLBACKS", self.DEJAVU_ONLY),
+            mock.patch("commons.design._BODY_BOLD_FALLBACKS", self.DEJAVU_ONLY),
+            mock.patch("commons.design._BODY_REGULAR_FALLBACKS", self.DEJAVU_ONLY),
+            self.assertLogs("commons.design", level="CRITICAL") as captured,
+        ):
+            self.assertFalse(verify_cjk_font_available())
+        self.assertIn("fonts-noto-cjk", captured.output[0])
+        self.assertIn("display", captured.output[0])
+
+    def test_fails_when_no_font_resolves_at_all(self) -> None:
+        """If no chain entry resolves (PIL default bitmap font), the check still fails."""
+        with (
+            mock.patch("commons.design._DISPLAY_FALLBACKS", self.ALL_MISSING),
+            mock.patch("commons.design._BODY_BOLD_FALLBACKS", self.ALL_MISSING),
+            mock.patch("commons.design._BODY_REGULAR_FALLBACKS", self.ALL_MISSING),
+            self.assertLogs("commons.design", level="CRITICAL"),
+        ):
+            self.assertFalse(verify_cjk_font_available())


### PR DESCRIPTION
## What

Hardens the slide-rendering font stack against a missing Noto CJK install (option (b) from the issue discussion — no font binaries committed).

- **`malcom/commons/design.py`** — new `verify_cjk_font_available()`: resolves each fallback chain (`display`, `body-bold`, `body-regular`) and probes actual glyph coverage by rendering hiragana `あ` and comparing it against the font's `.notdef` shape (rendered via the U+FFFE noncharacter, which no font maps). If any chain resolves to a Latin-only face, it logs **CRITICAL** naming the failing chain(s) and the `fonts-noto-cjk` remedy, and returns `False`.
- **`malcom/commons/apps.py`** — `CommonsConfig.ready()` calls the check, so any `manage.py` entry point surfaces a broken font install at startup instead of in published slides.
- **`malcom/commons/tests/test_design.py`** — 3 regression tests: passes in the normal environment; fails loudly when only DejaVu resolves (the silent-tofu scenario); fails when no chain entry resolves at all (PIL default bitmap font).
- **`README.md`** — documents the `fonts-noto-cjk` system dependency in the install steps.

## Why

`_load_font()` already walks the fallback chains and never raises — the original "survive missing Noto CJK" regression is fixed. But the final fallback (DejaVu) is Latin-only: if every Noto CJK face is missing, the chain still "succeeds" and Japanese text renders as tofu (□) **silently**. This makes that failure loud.

Interesting find while testing: `PIL.ImageFont.truetype` falls back to searching system font directories by basename, so even a wrong directory in the chain still resolves as long as the face is installed somewhere — the test simulating "all faces missing" must use a basename that exists nowhere.

## Test results

```
uv run poe test
Ran 461 tests in 104.949s
FAILED (errors=3)
```

- All 16 `commons.tests.test_design` tests pass (13 existing + 3 new).
- The 3 errors are **pre-existing on `main`** (verified by stashing this change and re-running): `houses.tests.test_video_slide_renderers.TestRenderShortsIntroSlide` (×2) and `houses.tests.test_generate_weekly_playlist_video_command` (×1) fail with `ValueError: not enough values to unpack (expected 6, got 3)` in the shorts intro slide renderer — unrelated to this change.
- `uv run poe check` (ruff): clean.
- `uv run pyright malcom/commons/design.py malcom/commons/apps.py`: 2 errors, both pre-existing on `main` (qrcode stubs), none introduced.

Closes #23
