### PR TITLE
fix: repair 3 pre-existing test errors in shorts video generation (tuple arity + env-dependent skip path)

### DIFF
--- a/malcom/houses/tests/test_generate_weekly_playlist_video_command.py
+++ b/malcom/houses/tests/test_generate_weekly_playlist_video_command.py
@@ -210,13 +210,14 @@ class TestGenerateWeeklyPlaylistVideoCommand(TestCase):
         mock_upload: MagicMock,
         mock_insert: MagicMock,
     ) -> None:
-        """AC: --format shorts routes to the shorts generator and never uploads/inserts."""
-        with tempfile.NamedTemporaryFile(suffix=".mp4") as tmp_video:
+        """AC: --format shorts routes to the shorts generator; without a secrets file nothing is uploaded/inserted."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.NamedTemporaryFile(suffix=".mp4") as tmp_video:
             mock_shorts_gen.return_value = Path(tmp_video.name)
             call_command(
                 "generate_weekly_playlist_video",
                 str(self.playlist.id),
                 format="shorts",
+                secrets_file=str(Path(tmp_dir) / "missing_client_secret.json"),
             )
 
         mock_shorts_gen.assert_called_once_with(self.playlist)

--- a/malcom/houses/tests/test_video_slide_renderers.py
+++ b/malcom/houses/tests/test_video_slide_renderers.py
@@ -127,12 +127,12 @@ class TestRenderVideoClosingSlide(TestCase):
 class TestRenderShortsIntroSlide(TestCase):
     def test_shorts_intro_with_full_lineup(self) -> None:
         lineup = [
-            (1, "残響のリフレイン", True),
-            (2, "OGRE YOU ASSHOLE", False),
-            (3, "tricot", False),
-            (4, "Mass of the Fermenting Dregs", False),
-            (5, "envy", True),
-            (6, "toe", False),
+            (1, "残響のリフレイン", True, None, "下北沢SHELTER", "13th Apr"),
+            (2, "OGRE YOU ASSHOLE", False, None, "新代田FEVER", "14th Apr"),
+            (3, "tricot", False, None, None, None),
+            (4, "Mass of the Fermenting Dregs", False, None, "渋谷CLUB QUATTRO", None),
+            (5, "envy", True, None, None, "16th Apr"),
+            (6, "toe", False, None, "代官山UNIT", "17th Apr"),
         ]
         img = render_shorts_intro_slide(title_label="Week of 2026-04-13", lineup=lineup)
         self.assertIsInstance(img, Image.Image)
@@ -143,7 +143,7 @@ class TestRenderShortsIntroSlide(TestCase):
         self.assertEqual(img.size, SHORTS_SIZE)
 
     def test_shorts_intro_caps_long_lineup(self) -> None:
-        oversized_lineup = [(i, f"Performer {i}", False) for i in range(1, 30)]
+        oversized_lineup = [(i, f"Performer {i}", False, None, f"Venue {i}", "1st Apr") for i in range(1, 30)]
         img = render_shorts_intro_slide(title_label="Big Month", lineup=oversized_lineup)
         self.assertEqual(img.size, SHORTS_SIZE)
 


### PR DESCRIPTION
Closes #118

## What changed

1. **`TestRenderShortsIntroSlide` (2 errors)** — the tests passed legacy 3-tuples to `render_shorts_intro_slide`, which unpacks the documented 6-tuple lineup contract `(position, name, spotlight, image_path, venue_label, date_label)` (`malcom/houses/functions.py:1000`). Tests now use 6-tuples mirroring the production call site (`functions.py:1607`), including `None` image/venue/date values.

2. **`test_format_shorts_invokes_shorts_generator_and_skips_upload` (1 error)** — the test relied on the default `--secrets-file ../client_secret.json` being absent. On machines where it exists, the command proceeded to the (mocked) upload and saved a `MagicMock` to `shorts_youtube_video_id` → `FieldError`. The test now passes an explicitly missing `--secrets-file` path, making the skip path deterministic in every environment (matching the sibling tests, which already pass `secrets_file` explicitly when they want the upload path).

## Test Plan

- `uv run poe test` on this branch: **Ran 461 tests ... OK** (main fails with `errors=3`)
- `ruff check` / `ruff format --check` clean; pre-commit hooks (ruff, gitleaks) passed on commit

## Notes

- Test-only change; no production code touched.
- ellen-goc is pull-only on this repo, so this is a cross-fork PR from `weyucou:fix/118-shorts-test-errors` — only the secret-scan job runs on fork PRs; the full suite was verified locally as above.