### PR TITLE
fix(youtube-search): anchor bracketed-pattern to title start; gate song creation on channel match

### DIFF
--- a/malcom/commons/youtube_search.py
+++ b/malcom/commons/youtube_search.py
@@ -123,9 +123,12 @@ class YouTubeSearcher:
         if re.match(artist_prefix_pattern, title_lower):
             return True
 
-        # Check for "[Artist]" or "(Artist)" patterns often used in titles
-        bracketed_pattern = rf"[\[\(【「『]{re.escape(performer_lower)}[\]\)】」』]"
-        return bool(re.search(bracketed_pattern, title_lower))
+        # Check for "[Artist]" or "(Artist)" patterns at the START of the title only.
+        # Using re.match (not re.search) prevents false positives where the performer
+        # name appears as a parenthesised song-title translation mid-title, e.g.
+        # "BTS - 잡아줘 (Hold Me Tight)" matching performer "Hold me tight".
+        bracketed_at_start = rf"^[\[\(【「『]{re.escape(performer_lower)}[\]\)】」』]"
+        return bool(re.match(bracketed_at_start, title_lower))
 
     def _extract_video_data_from_html(self, html_content: str) -> list[dict]:  # noqa: C901, PLR0912
         """
@@ -365,10 +368,29 @@ def search_and_create_performer_songs(performer: "Performer") -> list["Performer
 
     for video_data in videos_data:
         try:
+            video_title = video_data["title"]
+            title_lower = video_title.lower()
+            performer_lower = performer.name.lower().strip()
+            video_channel = video_data.get("channel_name", "")
+
+            # Gate song creation: require either the title to start with the performer
+            # name (strong "Artist - Song" signal) or the channel to match.
+            # Without this, searches for performer names like "Dope Flamingo" or
+            # "Hold me tight" pull in BTS / Bruno Mars videos whose titles happen to
+            # contain those words as song-title keywords.
+            if not title_lower.startswith(performer_lower) and not channel_name_matches(performer.name, video_channel):
+                logger.info(
+                    "Skipping '%s' for %s: title does not start with performer name and channel '%s' does not match",
+                    video_title,
+                    performer.name,
+                    video_channel,
+                )
+                continue
+
             # Create PerformerSong instance
             song = PerformerSong.objects.create(
                 performer=performer,
-                title=video_data["title"],
+                title=video_title,
                 duration=timedelta(seconds=video_data["duration_seconds"]),
                 youtube_video_id=video_data["video_id"],
                 youtube_url=video_data["youtube_url"],

--- a/malcom/performers/management/commands/audit_performer_songs.py
+++ b/malcom/performers/management/commands/audit_performer_songs.py
@@ -1,0 +1,80 @@
+"""Audit PerformerSong records for likely mismatches.
+
+A song is flagged as suspicious when:
+1. The video title does NOT start with the performer name (weak artist signal), AND
+2. No channel name is recorded (channel_name is not stored on PerformerSong) so we
+   fall back to checking whether the performer name appears anywhere in the title.
+
+This surfaces legacy rows created before the channel-match gate was added to
+search_and_create_performer_songs (see issue #131).
+"""
+
+import re
+
+from django.core.management.base import BaseCommand, CommandParser
+
+from performers.models import PerformerSong
+
+
+class Command(BaseCommand):
+    help = (
+        "Audit PerformerSong records for likely channel mismatches. "
+        "Reports songs whose title does not start with the performer name — "
+        "these are candidates for manual review or deletion."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--delete",
+            action="store_true",
+            help="Delete flagged songs (default: report only)",
+        )
+        parser.add_argument(
+            "--performer-ids",
+            nargs="+",
+            type=int,
+            default=None,
+            help="Limit audit to specific performer IDs",
+        )
+
+    def handle(self, *args, **options) -> None:  # noqa: ANN002, ANN003
+        delete: bool = options["delete"]
+        performer_ids: list[int] | None = options.get("performer_ids")
+
+        qs = PerformerSong.objects.select_related("performer").order_by("performer__name", "title")
+        if performer_ids:
+            qs = qs.filter(performer__id__in=performer_ids)
+
+        flagged: list[PerformerSong] = []
+        for song in qs:
+            performer_lower = song.performer.name.lower().strip()
+            title_lower = song.title.lower()
+            if title_lower.startswith(performer_lower):
+                continue
+            # Also skip when the performer name appears verbatim anywhere in the title
+            # (e.g. Japanese-name performers whose title is in kanji then the romaji
+            # name in parentheses).
+            if re.search(rf"\b{re.escape(performer_lower)}\b", title_lower):
+                continue
+            flagged.append(song)
+
+        if not flagged:
+            self.stdout.write(self.style.SUCCESS("No suspicious songs found."))
+            return
+
+        self.stdout.write(
+            self.style.WARNING(f"Found {len(flagged)} suspicious song(s) (title does not start with performer name):\n")
+        )
+        for song in flagged:
+            self.stdout.write(
+                f"  [song id={song.id}] performer='{song.performer.name}' (id={song.performer.id})\n"
+                f"    title: {song.title}\n"
+                f"    url:   {song.youtube_url}\n"
+            )
+
+        if delete:
+            ids = [s.id for s in flagged]
+            PerformerSong.objects.filter(id__in=ids).delete()
+            self.stdout.write(self.style.SUCCESS(f"\nDeleted {len(flagged)} song(s)."))
+        else:
+            self.stdout.write("\nRun with --delete to remove these songs, or review them manually via the admin.")

--- a/malcom/performers/tests/test_youtube_search.py
+++ b/malcom/performers/tests/test_youtube_search.py
@@ -188,6 +188,145 @@ class TestSearchAndCreatePerformerSongsChannelValidation(TestCase):
         self.assertEqual(link.platform_id, "UC_RAN")
 
 
+class TestIsRelevantToPerformer(TestCase):
+    """Tests for YouTubeSearcher._is_relevant_to_performer() — regression #131."""
+
+    def setUp(self) -> None:
+        self.searcher = YouTubeSearcher()
+
+    def _video(self, title: str, channel_name: str = "") -> dict:
+        return {"title": title, "channel_name": channel_name}
+
+    def test_title_starts_with_performer_matches(self) -> None:
+        self.assertTrue(
+            self.searcher._is_relevant_to_performer(  # noqa: SLF001
+                self._video("RAN - Official MV", "RAN"),
+                "RAN",
+            )
+        )
+
+    def test_performer_name_in_channel_matches(self) -> None:
+        self.assertTrue(
+            self.searcher._is_relevant_to_performer(  # noqa: SLF001
+                self._video("Live at Shibuya", "Hold me tight Official"),
+                "Hold me tight",
+            )
+        )
+
+    def test_bracketed_performer_at_title_start_matches(self) -> None:
+        """[Artist] or (Artist) at the very start of the title is a valid artist tag."""
+        self.assertTrue(
+            self.searcher._is_relevant_to_performer(  # noqa: SLF001
+                self._video("[Hold me tight] Official MV", ""),
+                "Hold me tight",
+            )
+        )
+
+    def test_bracketed_performer_mid_title_rejected(self) -> None:
+        """Regression #131: (PerformerName) appearing mid-title as a song-title translation
+        must NOT match — only bracket tags at the start of the title are accepted.
+        """
+        self.assertFalse(
+            self.searcher._is_relevant_to_performer(  # noqa: SLF001
+                self._video(
+                    "BTS (방탄소년단) - 잡아줘 (Hold Me Tight)  Live Concert in Japan",
+                    "BTS",
+                ),
+                "Hold me tight",
+            )
+        )
+
+    def test_bts_dope_title_rejected_for_dope_flamingo(self) -> None:
+        """Regression #131: 'BTS - DOPE' must not match performer 'Dope Flamingo'."""
+        self.assertFalse(
+            self.searcher._is_relevant_to_performer(  # noqa: SLF001
+                self._video(
+                    "BTS (방탄소년단) 'DOPE' (쩔어) Love Yourself : Speak Youself [Live Video ]",
+                    "BTS",
+                ),
+                "Dope Flamingo",
+            )
+        )
+
+    def test_gorilla_song_rejected_for_gorilla_snoc(self) -> None:
+        """Regression #131: 'Bruno Mars - Gorilla' must not match performer 'GORILLA SNOC'."""
+        self.assertFalse(
+            self.searcher._is_relevant_to_performer(  # noqa: SLF001
+                self._video("Bruno Mars - Gorilla (Live at iHeartRadio Music Festival 2013)", "Bruno Mars"),
+                "GORILLA SNOC",
+            )
+        )
+
+    def test_unrelated_video_rejected(self) -> None:
+        self.assertFalse(
+            self.searcher._is_relevant_to_performer(  # noqa: SLF001
+                self._video("Lady Gaga - Bad Romance", "Lady Gaga"),
+                "RAN",
+            )
+        )
+
+
+class TestSearchAndCreateSongCreationGate(TestCase):
+    """Regression #131: songs must not be stored when title doesn't start with performer
+    name AND channel name doesn't match.
+    """
+
+    @patch("commons.youtube_search.YouTubeSearcher.search_most_popular_videos")
+    def test_bts_hold_me_tight_not_stored_for_hold_me_tight_performer(self, mock_search: MagicMock) -> None:
+        performer = _create_performer("Hold me tight")
+        mock_search.return_value = [
+            {
+                "video_id": "bts_hold",
+                "title": "BTS (방탄소년단) - 잡아줘 (Hold Me Tight)  Live Concert in Japan",
+                "channel_name": "BTS",
+                "channel_id": "UC_BTS",
+                "youtube_url": "https://www.youtube.com/watch?v=bts_hold",
+                "view_count": 5_000_000,
+                "duration_seconds": 240,
+            }
+        ]
+        songs = search_and_create_performer_songs(performer)
+        self.assertEqual(songs, [], "BTS 'Hold Me Tight' must not be stored for performer 'Hold me tight'")
+
+    @patch("commons.youtube_search.YouTubeSearcher.search_most_popular_videos")
+    def test_correct_song_created_when_title_starts_with_performer(self, mock_search: MagicMock) -> None:
+        """A song whose title starts with the performer name is stored even if it's the only signal."""
+        performer = _create_performer("Hold me tight")
+        mock_search.return_value = [
+            {
+                "video_id": "hmt_vid",
+                "title": "Hold me tight - Official MV 2024",
+                "channel_name": "Unknown Label",
+                "channel_id": "UC_UNKNOWN",
+                "youtube_url": "https://www.youtube.com/watch?v=hmt_vid",
+                "view_count": 10_000,
+                "duration_seconds": 210,
+            }
+        ]
+        songs = search_and_create_performer_songs(performer)
+        self.assertEqual(len(songs), 1)
+        self.assertEqual(songs[0].title, "Hold me tight - Official MV 2024")
+
+    @patch("commons.youtube_search.YouTubeSearcher.search_most_popular_videos")
+    def test_correct_song_created_when_channel_matches(self, mock_search: MagicMock) -> None:
+        """A song is stored when channel name matches even if title doesn't start with performer."""
+        performer = _create_performer("Hold me tight")
+        mock_search.return_value = [
+            {
+                "video_id": "hmt_live",
+                "title": "Live at Shinjuku 2024 - Hold me tight",
+                "channel_name": "Hold me tight",
+                "channel_id": "UC_HMT",
+                "youtube_url": "https://www.youtube.com/watch?v=hmt_live",
+                "view_count": 5_000,
+                "duration_seconds": 300,
+            }
+        ]
+        songs = search_and_create_performer_songs(performer)
+        self.assertEqual(len(songs), 1)
+        self.assertEqual(songs[0].title, "Live at Shinjuku 2024 - Hold me tight")
+
+
 class TestParseDuration(TestCase):
     """Tests for YouTubeSearcher._parse_duration()."""
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `commons/youtube_search.py` that caused Bruno Mars, BTS, and other major-label songs to be stored as sample songs for local hakoake performers.

- **Bug 1** — `_is_relevant_to_performer` used `re.search` for its bracketed artist-tag pattern. Any video title containing the performer name in parentheses anywhere matched, e.g. `"BTS - 잡아줘 (Hold Me Tight)"` matched performer `"Hold me tight"`. Fixed: changed to `re.match` so the bracketed form is only accepted when it appears at the very start of the title.
- **Bug 2** — `search_and_create_performer_songs` called `PerformerSong.objects.create()` unconditionally before checking the YouTube channel, then `continue`d on a channel mismatch — but the song was already in the database. Fixed: before creating a `PerformerSong`, the function now validates that either the title starts with the performer name, or `channel_name_matches` passes. Songs that fail both checks are skipped with an INFO log.
- **Audit command** — Added `audit_performer_songs` management command to surface existing stale songs for manual cleanup: `python manage.py audit_performer_songs [--delete] [--performer-ids ...]`

Closes #131

## Test plan

- [ ] All 41 tests in `performers.tests.test_youtube_search` pass (`uv run python manage.py test performers.tests.test_youtube_search`)
- [ ] New `TestIsRelevantToPerformer` class covers the bracketed false-positive cases for "Hold me tight", "Dope Flamingo", "GORILLA SNOC"
- [ ] New `TestSearchAndCreateSongCreationGate` class confirms BTS "Hold Me Tight" is not stored for performer "Hold me tight", and correct songs still flow through when title starts with performer or channel matches
- [ ] `audit_performer_songs --dry-run` on staging DB surfaces the 10 known bad songs without deleting anything