### PR TITLE
feat(crawler): implement CycloneCrawler for Shibuya CYCLONE

### DIFF
--- a/malcom/houses/crawlers/__init__.py
+++ b/malcom/houses/crawlers/__init__.py
@@ -9,6 +9,7 @@ from .daisy_bar import DaisyBarCrawler
 from .rockmaykan import RockmaykanCrawler
 from .club_que import ClubQueCrawler
 from .garret import GarretCrawler
+from .cyclone import CycloneCrawler
 from .fever_popo import FeverPopoCrawler
 from .shibuya_o_nest import ShibuyaONestCrawler
 from .pit_zero import PitZeroCrawler
@@ -26,6 +27,7 @@ __all__ = [
     "RockmaykanCrawler",
     "ClubQueCrawler",
     "GarretCrawler",
+    "CycloneCrawler",
     "FeverPopoCrawler",
     "ShibuyaONestCrawler",
     "PitZeroCrawler",

--- a/malcom/houses/crawlers/cyclone.py
+++ b/malcom/houses/crawlers/cyclone.py
@@ -1,0 +1,66 @@
+import logging
+import re
+
+from bs4 import Tag
+from django.utils import timezone
+
+from .crawler import CrawlerRegistry
+from .garret import DECEMBER, GarretCrawler
+
+logger = logging.getLogger(__name__)
+
+SCHEDULE_URL_TEMPLATE = "http://www.cyclone1997.com/schedule/{year}schedule_{month}.html"
+
+
+@CrawlerRegistry.register("CycloneCrawler")
+class CycloneCrawler(GarretCrawler):
+    """Crawler for Shibuya CYCLONE (http://www.cyclone1997.com/schedule/).
+
+    Same cyclone1997.com domain and HTML structure as GarretCrawler, but with a
+    different URL path and `cyclone_day/` image directory.
+    """
+
+    def extract_live_house_info(self, html_content: str) -> dict:
+        return {
+            "name": "CYCLONE",
+            "name_kana": "サイクロン",
+            "name_romaji": "CYCLONE",
+            "address": "",
+            "phone_number": "",
+            "capacity": 0,
+            "opened_date": None,
+        }
+
+    def find_schedule_link(self, html_content: str) -> str | None:
+        current_date = timezone.localdate()
+        return SCHEDULE_URL_TEMPLATE.format(year=current_date.year, month=current_date.month)
+
+    def _extract_day_from_images(self, td: Tag) -> int | None:
+        for img in td.find_all("img"):
+            src = img.get("src", "")
+            match = re.search(r"cyclone_day/(\d+)\.jpg", src)
+            if match:
+                return int(match.group(1))
+        return None
+
+    def find_next_month_link(self, html_content: str) -> str | None:
+        soup = self.create_soup(html_content)
+        current_year, current_month = self._extract_year_month(soup)
+        if not current_year or not current_month:
+            return None
+
+        for link in soup.find_all("a", href=True):
+            href = link["href"]
+            match = re.search(r"(\d{4})schedule_(\d{1,2})\.html", href)
+            if not match:
+                continue
+
+            link_year = int(match.group(1))
+            link_month = int(match.group(2))
+
+            if link_year == current_year and link_month == current_month + 1:
+                return SCHEDULE_URL_TEMPLATE.format(year=link_year, month=link_month)
+            if link_year == current_year + 1 and current_month == DECEMBER and link_month == 1:
+                return SCHEDULE_URL_TEMPLATE.format(year=link_year, month=link_month)
+
+        return None

--- a/malcom/houses/migrations/0016_set_cyclone_crawler_class.py
+++ b/malcom/houses/migrations/0016_set_cyclone_crawler_class.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def set_cyclone_crawler_class(apps, schema_editor):
+    LiveHouseWebsite = apps.get_model("houses", "LiveHouseWebsite")
+    LiveHouseWebsite.objects.filter(id=11).update(crawler_class="CycloneCrawler")
+
+
+def reverse_cyclone_crawler_class(apps, schema_editor):
+    LiveHouseWebsite = apps.get_model("houses", "LiveHouseWebsite")
+    LiveHouseWebsite.objects.filter(id=11, crawler_class="CycloneCrawler").update(
+        crawler_class="LiveHouseWebsiteCrawler"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("houses", "0015_weeklyplaylist_instagram_story_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_cyclone_crawler_class, reverse_cyclone_crawler_class),
+    ]

--- a/malcom/houses/tests/test_crawlers_cyclone.py
+++ b/malcom/houses/tests/test_crawlers_cyclone.py
@@ -1,0 +1,125 @@
+from django.test import TestCase
+
+from houses.crawlers import CycloneCrawler
+from houses.definitions import WebsiteProcessingState
+from houses.models import LiveHouseWebsite
+
+# Minimal June 2026 schedule HTML with two events
+SCHEDULE_HTML = """\
+<html lang="ja"><head><meta charset="Shift_JIS"></head><body>
+<font size="+2">
+<a href="2026schedule_5.html"><img src="../image/logo_left_b.jpg"></a>
+<b> 2026.<strong>6 June </strong></b>
+<a href="2026schedule_7.html"><img src="../image/logo_right_b.jpg"></a>
+</font>
+<hr>
+<table cellpadding="0">
+  <tr>
+    <td width="80" height="90" align="center" valign="middle"><em><strong>
+      <img src="../image/cyclone_day/01.jpg" alt="" height="40" width="40"><br>
+      <img src="../image/cyclone_week/1mon.jpg" alt="" height="14" width="40"><br>
+    </strong></em></td>
+    <td width="700" valign="middle"><p><span style="font-size: 10px">SHIBUYA CYCLONE pre.<br>
+      <br>
+      <span style="font-size: 10px; font-weight: normal;"><span style="font-size: 14px"><strong>
+        BandA / BandB / BandC
+      </strong></span></span><br>
+      OPEN 18:00| START 18:30<br>
+    </span></p></td>
+  </tr>
+</table>
+<hr>
+<table cellpadding="0">
+  <tr>
+    <td width="80" height="90" align="center" valign="middle"><em><strong>
+      <img src="../image/cyclone_day/29.jpg" alt="" height="40" width="40"><br>
+    </strong></em></td>
+    <td width="700" valign="middle"><p><span style="font-size: 10px">
+      <span style="font-size: 10px; font-weight: normal;"><span style="font-size: 14px"><strong>
+        ナカノバンド / ヤマグチバンド
+      </strong></span></span><br>
+      OPEN 17:30 | START 18:00<br>
+    </span></p></td>
+  </tr>
+</table>
+<hr>
+</body></html>
+"""
+
+# HTML with no next-month link
+NO_NEXT_MONTH_HTML = """\
+<html lang="ja"><body>
+<font size="+2">
+<a href="2026schedule_5.html"><img></a>
+<b> 2026.<strong>6 June </strong></b>
+</font>
+</body></html>
+"""
+
+
+class TestCycloneCrawler(TestCase):
+    def setUp(self):
+        self.website = LiveHouseWebsite.objects.create(
+            url="http://www.cyclone1997.com/schedule/",
+            state=WebsiteProcessingState.NOT_STARTED,
+            crawler_class="CycloneCrawler",
+        )
+        self.crawler = CycloneCrawler(self.website)
+
+    def test_extract_live_house_info(self):
+        info = self.crawler.extract_live_house_info("")
+        self.assertEqual(info["name"], "CYCLONE")
+        self.assertEqual(info["name_romaji"], "CYCLONE")
+
+    def test_find_schedule_link_single_digit_month(self):
+        import datetime
+        from unittest.mock import patch
+
+        with patch("houses.crawlers.cyclone.timezone") as mock_tz:
+            mock_tz.localdate.return_value = datetime.date(2026, 6, 1)
+            url = self.crawler.find_schedule_link("")
+        self.assertEqual(url, "http://www.cyclone1997.com/schedule/2026schedule_6.html")
+
+    def test_find_schedule_link_double_digit_month(self):
+        import datetime
+        from unittest.mock import patch
+
+        with patch("houses.crawlers.cyclone.timezone") as mock_tz:
+            mock_tz.localdate.return_value = datetime.date(2026, 11, 1)
+            url = self.crawler.find_schedule_link("")
+        self.assertEqual(url, "http://www.cyclone1997.com/schedule/2026schedule_11.html")
+
+    def test_extract_schedules_parses_dates_and_performers(self):
+        schedules = self.crawler.extract_performance_schedules(SCHEDULE_HTML)
+        self.assertEqual(len(schedules), 2)
+
+        june1 = schedules[0]
+        self.assertEqual(june1["date"], "2026-06-01")
+        self.assertEqual(june1["open_time"], "18:00")
+        self.assertEqual(june1["start_time"], "18:30")
+        self.assertIn("BandA", june1["performers"])
+        self.assertIn("BandB", june1["performers"])
+        self.assertIn("BandC", june1["performers"])
+
+        june29 = schedules[1]
+        self.assertEqual(june29["date"], "2026-06-29")
+        self.assertEqual(june29["open_time"], "17:30")
+        self.assertEqual(june29["start_time"], "18:00")
+        self.assertIn("ナカノバンド", june29["performers"])
+        self.assertIn("ヤマグチバンド", june29["performers"])
+
+    def test_find_next_month_link(self):
+        url = self.crawler.find_next_month_link(SCHEDULE_HTML)
+        self.assertEqual(url, "http://www.cyclone1997.com/schedule/2026schedule_7.html")
+
+    def test_find_next_month_link_none_when_no_forward_link(self):
+        url = self.crawler.find_next_month_link(NO_NEXT_MONTH_HTML)
+        self.assertIsNone(url)
+
+    def test_cyclone_day_images_used_not_garret(self):
+        """Day extraction uses cyclone_day/ image path, not garret_day/."""
+        soup = self.crawler.create_soup(SCHEDULE_HTML)
+        first_table = soup.find("table")
+        left_td = first_table.find("td")
+        day = self.crawler._extract_day_from_images(left_td)
+        self.assertEqual(day, 1)


### PR DESCRIPTION
## Summary

- Adds `CycloneCrawler` inheriting from `GarretCrawler` (same `cyclone1997.com` domain, Shift-JIS table layout, identical HTML structure)
- Overrides `find_schedule_link` → `http://www.cyclone1997.com/schedule/{year}schedule_{month}.html`
- Overrides `_extract_day_from_images` → matches `cyclone_day/` image path instead of Garret's `garret_day/`
- Overrides `find_next_month_link` → matches relative href pattern `(\d{4})schedule_(\d{1,2})\.html`
- Adds data migration `0016_set_cyclone_crawler_class` to set venue 11 `crawler_class` to `CycloneCrawler`
- 7 unit tests passing (fixture-based, no live HTTP)

## DB update method

Data migration `0016_set_cyclone_crawler_class.py` — reproducible in CI, reversible.

Closes #126