### PR TITLE
feat(crawler): implement ClubQuattroCrawler for Shibuya CLUB QUATTRO

### DIFF
--- a/malcom/houses/crawlers/__init__.py
+++ b/malcom/houses/crawlers/__init__.py
@@ -12,6 +12,7 @@ from .garret import GarretCrawler
 from .fever_popo import FeverPopoCrawler
 from .shibuya_o_nest import ShibuyaONestCrawler
 from .pit_zero import PitZeroCrawler
+from .club_quattro import ClubQuattroCrawler
 
 __all__ = [
     "LiveHouseWebsiteCrawler",
@@ -29,4 +30,5 @@ __all__ = [
     "FeverPopoCrawler",
     "ShibuyaONestCrawler",
     "PitZeroCrawler",
+    "ClubQuattroCrawler",
 ]

--- a/malcom/houses/crawlers/club_quattro.py
+++ b/malcom/houses/crawlers/club_quattro.py
@@ -1,0 +1,135 @@
+import logging
+import re
+
+import requests
+from bs4 import BeautifulSoup
+from django.utils import timezone
+
+from .crawler import CrawlerRegistry, LiveHouseWebsiteCrawler
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://en.club-quattro.com/shibuya/schedule/"
+TIME_PATTERN = re.compile(r"(\d{1,2}:\d{2})\s*/\s*(\d{1,2}:\d{2})")
+
+
+@CrawlerRegistry.register("ClubQuattroCrawler")
+class ClubQuattroCrawler(LiveHouseWebsiteCrawler):
+    """Crawler for Shibuya CLUB QUATTRO (https://en.club-quattro.com/shibuya/schedule/)."""
+
+    def extract_live_house_info(self, html_content: str) -> dict:
+        return {
+            "name": "CLUB QUATTRO",
+            "name_kana": "クラブクアトロ",
+            "name_romaji": "CLUB QUATTRO",
+            "address": "",
+            "phone_number": "",
+            "capacity": 0,
+            "opened_date": None,
+        }
+
+    def find_schedule_link(self, html_content: str) -> str | None:
+        current = timezone.localdate()
+        return f"{BASE_URL}?ym={current.year}{current.month:02d}"
+
+    def find_next_month_link(self, html_content: str) -> str | None:
+        soup = self.create_soup(html_content)
+        year, month = self._extract_year_month(soup)
+        if not year or not month:
+            return None
+
+        next_month = month + 1
+        next_year = year
+        if next_month > 12:  # noqa: PLR2004
+            next_month = 1
+            next_year += 1
+
+        target_ym = f"{next_year}{next_month:02d}"
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if f"ym={target_ym}" in href:
+                return href
+
+        return None
+
+    def extract_performance_schedules(self, html_content: str) -> list[dict]:
+        soup = self.create_soup(html_content)
+        year, month = self._extract_year_month(soup)
+        if not year or not month:
+            logger.warning("Could not extract year/month from Club Quattro schedule page")
+            return []
+
+        schedules = []
+        for box in soup.find_all("div", class_="event-box"):
+            schedule = self._parse_event_box(box, year, month)
+            if schedule:
+                schedules.append(schedule)
+
+        logger.info(f"Extracted {len(schedules)} schedules from Club Quattro page ({year}-{month:02d})")
+        return schedules
+
+    def _extract_year_month(self, soup: BeautifulSoup) -> tuple[int | None, int | None]:
+        year_tag = soup.find(class_="year")
+        month_tag = soup.find(class_="month")
+        try:
+            return int(year_tag.get_text().strip()), int(month_tag.get_text().strip())
+        except (AttributeError, ValueError):
+            return None, None
+
+    def _parse_event_box(self, box: BeautifulSoup, year: int, month: int) -> dict | None:
+        day_tag = box.find("p", class_="day")
+        if not day_tag:
+            return None
+        try:
+            day = int(day_tag.get_text().strip())
+        except ValueError:
+            return None
+
+        performers = self._extract_performers(box)
+        if not performers:
+            return None
+
+        event_name_tag = box.find("p", class_="txt-02")
+        event_name = event_name_tag.get_text().strip() if event_name_tag else None
+
+        open_time, start_time = self._extract_times(box)
+
+        return {
+            "date": f"{year}-{month:02d}-{day:02d}",
+            "open_time": open_time,
+            "start_time": start_time,
+            "performers": performers,
+            "performance_name": event_name,
+        }
+
+    def _extract_performers(self, box: BeautifulSoup) -> list[str]:
+        txt01 = box.find("p", class_="txt-01")
+        if not txt01:
+            return []
+        hv_elm = txt01.find(class_="hv-elm")
+        name = (hv_elm or txt01).get_text().strip()
+        return [name] if name else []
+
+    def _extract_times(self, box: BeautifulSoup) -> tuple[str | None, str | None]:
+        detail_list = box.find("dl", class_="detail-list")
+        if not detail_list:
+            return None, None
+        first_dd = detail_list.find("dd")
+        if not first_dd:
+            return None, None
+        text = first_dd.get_text().strip()
+        match = TIME_PATTERN.search(text)
+        if match:
+            return match.group(1), match.group(2)
+        return None, None
+
+    def fetch_next_month_schedules(self, html_content: str) -> list[dict]:
+        next_url = self.find_next_month_link(html_content)
+        if not next_url:
+            return []
+        try:
+            next_html = self.fetch_page(next_url)
+            return self.extract_performance_schedules(next_html)
+        except requests.Timeout:
+            logger.warning(f"Timeout fetching next-month Club Quattro page: {next_url}")
+            return []

--- a/malcom/houses/migrations/0016_set_club_quattro_crawler_class.py
+++ b/malcom/houses/migrations/0016_set_club_quattro_crawler_class.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def set_club_quattro_crawler_class(apps, schema_editor):
+    LiveHouseWebsite = apps.get_model("houses", "LiveHouseWebsite")
+    LiveHouseWebsite.objects.filter(id=7).update(crawler_class="ClubQuattroCrawler")
+
+
+def reverse_club_quattro_crawler_class(apps, schema_editor):
+    LiveHouseWebsite = apps.get_model("houses", "LiveHouseWebsite")
+    LiveHouseWebsite.objects.filter(id=7, crawler_class="ClubQuattroCrawler").update(
+        crawler_class="LiveHouseWebsiteCrawler"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("houses", "0015_weeklyplaylist_instagram_story_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_club_quattro_crawler_class, reverse_club_quattro_crawler_class),
+    ]

--- a/malcom/houses/tests/test_crawlers_club_quattro.py
+++ b/malcom/houses/tests/test_crawlers_club_quattro.py
@@ -1,0 +1,122 @@
+from django.test import TestCase
+
+from houses.crawlers import ClubQuattroCrawler
+from houses.definitions import WebsiteProcessingState
+from houses.models import LiveHouseWebsite
+
+SCHEDULE_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Schedule | Shibuya Club Quattro</title></head>
+<body>
+<span class="year">2026</span>
+<span class="month">06</span>
+<a href="https://en.club-quattro.com/shibuya/schedule/?ym=202607">next</a>
+<div class="event-box">
+  <a href="https://en.club-quattro.com/shibuya/schedule/detail/?cd=018366">
+    <div class="date-wrap">
+      <div class="date">
+        <p class="day">01</p>
+        <p class="week">MON.</p>
+      </div>
+    </div>
+    <div class="cmn-event-info">
+      <p class="txt-01"><span class="hv-elm">SHE'S</span></p>
+      <p class="txt-02">SHE'S 15th Anniversary</p>
+      <dl class="detail-list">
+        <dt>Opening/Starting</dt>
+        <dd>18:00 / 18:45</dd>
+        <dd>Advance sale ¥5,500</dd>
+      </dl>
+    </div>
+  </a>
+</div>
+<div class="event-box">
+  <a href="https://en.club-quattro.com/shibuya/schedule/detail/?cd=018400">
+    <div class="date-wrap">
+      <div class="date">
+        <p class="day">15</p>
+        <p class="week">MON.</p>
+      </div>
+    </div>
+    <div class="cmn-event-info">
+      <p class="txt-01"><span class="hv-elm">テストバンド</span></p>
+      <p class="txt-02">Summer Tour 2026</p>
+      <dl class="detail-list">
+        <dt>Opening/Starting</dt>
+        <dd>17:30 / 18:00</dd>
+      </dl>
+    </div>
+  </a>
+</div>
+</body>
+</html>
+"""
+
+NO_YEAR_MONTH_HTML = """\
+<html><body>
+<div class="event-box">
+  <p class="day">01</p>
+</div>
+</body></html>
+"""
+
+
+class TestClubQuattroCrawler(TestCase):
+    def setUp(self):
+        self.website = LiveHouseWebsite.objects.create(
+            url="https://en.club-quattro.com/shibuya/schedule/",
+            state=WebsiteProcessingState.NOT_STARTED,
+            crawler_class="ClubQuattroCrawler",
+        )
+        self.crawler = ClubQuattroCrawler(self.website)
+
+    def test_extract_live_house_info(self):
+        info = self.crawler.extract_live_house_info("")
+        self.assertEqual(info["name"], "CLUB QUATTRO")
+        self.assertEqual(info["name_romaji"], "CLUB QUATTRO")
+
+    def test_find_schedule_link_format(self):
+        import datetime
+        from unittest.mock import patch
+
+        with patch("houses.crawlers.club_quattro.timezone") as mock_tz:
+            mock_tz.localdate.return_value = datetime.date(2026, 6, 1)
+            url = self.crawler.find_schedule_link("")
+        self.assertEqual(url, "https://en.club-quattro.com/shibuya/schedule/?ym=202606")
+
+    def test_extract_schedules_parses_two_events(self):
+        schedules = self.crawler.extract_performance_schedules(SCHEDULE_HTML)
+        self.assertEqual(len(schedules), 2)
+
+        june1 = schedules[0]
+        self.assertEqual(june1["date"], "2026-06-01")
+        self.assertEqual(june1["open_time"], "18:00")
+        self.assertEqual(june1["start_time"], "18:45")
+        self.assertIn("SHE'S", june1["performers"])
+        self.assertEqual(june1["performance_name"], "SHE'S 15th Anniversary")
+
+        june15 = schedules[1]
+        self.assertEqual(june15["date"], "2026-06-15")
+        self.assertEqual(june15["open_time"], "17:30")
+        self.assertEqual(june15["start_time"], "18:00")
+        self.assertIn("テストバンド", june15["performers"])
+
+    def test_extract_schedules_no_year_month_returns_empty(self):
+        schedules = self.crawler.extract_performance_schedules(NO_YEAR_MONTH_HTML)
+        self.assertEqual(schedules, [])
+
+    def test_find_next_month_link(self):
+        url = self.crawler.find_next_month_link(SCHEDULE_HTML)
+        self.assertEqual(url, "https://en.club-quattro.com/shibuya/schedule/?ym=202607")
+
+    def test_find_next_month_link_year_rollover(self):
+        html = """\
+        <html><body>
+        <span class="year">2026</span>
+        <span class="month">12</span>
+        <a href="https://en.club-quattro.com/shibuya/schedule/?ym=202701">jan</a>
+        </body></html>
+        """
+        url = self.crawler.find_next_month_link(html)
+        self.assertEqual(url, "https://en.club-quattro.com/shibuya/schedule/?ym=202701")


### PR DESCRIPTION
## Summary

- Adds `ClubQuattroCrawler` for `https://en.club-quattro.com/shibuya/schedule/`
- Parses static HTML `.event-box` elements (no Playwright needed despite 204KB page)
- Year/month from `.year`/`.month` class elements; month navigation via `?ym=YYYYMM`
- Performer from `.txt-01 .hv-elm`, event name from `.txt-02`, times from `dl.detail-list dd` (format `18:00 / 18:45`)
- Graceful `requests.Timeout` handling for next-month fetches
- 6 unit tests passing (fixture HTML, no live HTTP)
- Data migration `0016_set_club_quattro_crawler_class` sets venue 7 `crawler_class` to `ClubQuattroCrawler`

## DB update method

Data migration `0016_set_club_quattro_crawler_class.py` — reproducible, reversible.

Closes #130