### PR TITLE
feat(crawler): implement SeventhFloorCrawler and fix 404 schedule URL

### DIFF
--- a/malcom/houses/crawlers/__init__.py
+++ b/malcom/houses/crawlers/__init__.py
@@ -15,6 +15,7 @@ from .shibuya_o_nest import ShibuyaONestCrawler
 from .pit_zero import PitZeroCrawler
 from .club_quattro import ClubQuattroCrawler
 from .shinjuku_face import ShinjukuFaceCrawler
+from .seventh_floor import SeventhFloorCrawler
 
 __all__ = [
     "LiveHouseWebsiteCrawler",
@@ -35,4 +36,5 @@ __all__ = [
     "PitZeroCrawler",
     "ClubQuattroCrawler",
     "ShinjukuFaceCrawler",
+    "SeventhFloorCrawler",
 ]

--- a/malcom/houses/crawlers/seventh_floor.py
+++ b/malcom/houses/crawlers/seventh_floor.py
@@ -1,0 +1,120 @@
+import logging
+import re
+
+from bs4 import BeautifulSoup
+from django.utils import timezone
+
+from .crawler import CrawlerRegistry, LiveHouseWebsiteCrawler
+
+logger = logging.getLogger(__name__)
+
+SCHEDULE_URL = "http://7th-floor.net/event/"
+
+
+@CrawlerRegistry.register("SeventhFloorCrawler")
+class SeventhFloorCrawler(LiveHouseWebsiteCrawler):
+    """Crawler for Shibuya 7th Floor (http://7th-floor.net/event/).
+
+    The page loads all historical events as div.eventList elements. Each element
+    carries a CSS class in the format YYYY-M (e.g. 2026-6) for year-month matching.
+    Date is in span.date as MM.DD, artists in ul.artists > li, event title in h2 span.evTit.
+    """
+
+    def extract_live_house_info(self, html_content: str) -> dict:
+        return {
+            "name": "7th Floor",
+            "name_kana": "セブンスフロア",
+            "name_romaji": "7th Floor",
+            "address": "",
+            "phone_number": "",
+            "capacity": 0,
+            "opened_date": None,
+        }
+
+    def find_schedule_link(self, html_content: str) -> str | None:
+        current = timezone.localdate()
+        return f"{SCHEDULE_URL}?ym={current.year}-{current.month}"
+
+    def find_next_month_link(self, html_content: str) -> str | None:
+        """Construct next-month URL — the site loads all events on one page."""
+        soup = self.create_soup(html_content)
+        year, month = self._extract_target_year_month(soup)
+        if not year or not month:
+            return None
+        next_month = month + 1
+        next_year = year
+        if next_month > 12:  # noqa: PLR2004
+            next_month = 1
+            next_year += 1
+        return f"{SCHEDULE_URL}?ym={next_year}-{next_month}"
+
+    def extract_performance_schedules(self, html_content: str) -> list[dict]:
+        soup = self.create_soup(html_content)
+        year, month = self._extract_target_year_month(soup)
+        if not year or not month:
+            logger.warning("Could not determine target year/month for 7th Floor schedule")
+            return []
+
+        target_class = f"{year}-{month}"
+        schedules = []
+        for div in soup.find_all("div", class_="eventList"):
+            classes = div.get("class", [])
+            if target_class not in classes:
+                continue
+            schedule = self._parse_event_div(div, year, month)
+            if schedule:
+                schedules.append(schedule)
+
+        logger.info(f"Extracted {len(schedules)} schedules from 7th Floor page ({year}-{month:02d})")
+        return schedules
+
+    def _extract_target_year_month(self, soup: BeautifulSoup) -> tuple[int | None, int | None]:
+        """Derive target year/month from the page URL embedded in the canonical link or from today."""
+        canonical = soup.find("link", rel="canonical")
+        if canonical:
+            href = canonical.get("href", "")
+            match = re.search(r"\?ym=(\d{4})-(\d{1,2})", href)
+            if match:
+                return int(match.group(1)), int(match.group(2))
+
+        today = timezone.localdate()
+        return today.year, today.month
+
+    def _parse_event_div(self, div: BeautifulSoup, year: int, month: int) -> dict | None:
+        date_span = div.find("span", class_="date")
+        if not date_span:
+            return None
+        try:
+            date_text = date_span.get_text().strip()
+            month_part, day_part = date_text.split(".")
+            if int(month_part) != month:
+                return None
+            day = int(day_part)
+        except (ValueError, AttributeError):
+            return None
+
+        performers = self._extract_performers(div)
+        if not performers:
+            return None
+
+        ev_tit = div.find("span", class_="evTit")
+        event_name = ev_tit.get_text().strip() if ev_tit else None
+
+        return {
+            "date": f"{year}-{month:02d}-{day:02d}",
+            "open_time": None,
+            "start_time": None,
+            "performers": performers,
+            "performance_name": event_name,
+        }
+
+    def _extract_performers(self, div: BeautifulSoup) -> list[str]:
+        artists_ul = div.find("ul", class_="artists")
+        if not artists_ul:
+            return []
+        performers = []
+        for li in artists_ul.find_all("li"):
+            text = li.get_text().strip()
+            if text:
+                performers.append(text)
+        return performers

--- a/malcom/houses/migrations/0016_set_seventh_floor_crawler_class.py
+++ b/malcom/houses/migrations/0016_set_seventh_floor_crawler_class.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def set_seventh_floor_crawler_class(apps, schema_editor):
+    LiveHouseWebsite = apps.get_model("houses", "LiveHouseWebsite")
+    LiveHouseWebsite.objects.filter(id=8).update(
+        crawler_class="SeventhFloorCrawler",
+        schedule_url="http://7th-floor.net/event/",
+    )
+
+
+def reverse_seventh_floor_crawler_class(apps, schema_editor):
+    LiveHouseWebsite = apps.get_model("houses", "LiveHouseWebsite")
+    LiveHouseWebsite.objects.filter(id=8, crawler_class="SeventhFloorCrawler").update(
+        crawler_class="LiveHouseWebsiteCrawler",
+        schedule_url="http://7th-floor.net/schedules/",
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("houses", "0015_weeklyplaylist_instagram_story_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_seventh_floor_crawler_class, reverse_seventh_floor_crawler_class),
+    ]

--- a/malcom/houses/tests/test_crawlers_seventh_floor.py
+++ b/malcom/houses/tests/test_crawlers_seventh_floor.py
@@ -1,0 +1,129 @@
+from django.test import TestCase
+
+from houses.crawlers import SeventhFloorCrawler
+from houses.definitions import WebsiteProcessingState
+from houses.models import LiveHouseWebsite
+
+SCHEDULE_HTML = """\
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<title>渋谷 7thFLOOR schedule</title>
+<link rel="canonical" href="http://7th-floor.net/event/?ym=2026-6"/>
+</head>
+<body>
+<div class="eventList 2026-6">
+<a href="http://7th-floor.net/event/test-event-1/">
+<div class="headerWrap">
+<div class="dateWrap">
+<span class="date">06.07</span>
+<span class="week">(日)</span>
+</div>
+</div>
+<div class="infoWrap">
+<h2><span class="evTit">Summer Acoustic Night</span></h2>
+<ul class="artists">
+<li>テストアーティスト1 / テストアーティスト2</li>
+</ul>
+</div>
+</a>
+</div>
+<div class="eventList 2026-6">
+<a href="http://7th-floor.net/event/test-event-2/">
+<div class="headerWrap">
+<div class="dateWrap">
+<span class="date">06.20</span>
+<span class="week">(土)</span>
+</div>
+</div>
+<div class="infoWrap">
+<h2><span class="evTit">Jazz Session Vol.5</span></h2>
+<ul class="artists">
+<li>BandX</li>
+</ul>
+</div>
+</a>
+</div>
+<div class="eventList 2026-5">
+<a href="http://7th-floor.net/event/may-event/">
+<div class="headerWrap">
+<div class="dateWrap">
+<span class="date">05.10</span>
+</div>
+</div>
+<div class="infoWrap">
+<h2><span class="evTit">May Event</span></h2>
+<ul class="artists"><li>OldBand</li></ul>
+</div>
+</a>
+</div>
+</body>
+</html>
+"""
+
+NO_CANONICAL_HTML = """\
+<html><body>
+<div class="eventList 2026-7">
+<span class="date">07.01</span>
+<ul class="artists"><li>BandA</li></ul>
+</div>
+</body></html>
+"""
+
+
+class TestSeventhFloorCrawler(TestCase):
+    def setUp(self):
+        self.website = LiveHouseWebsite.objects.create(
+            url="http://7th-floor.net/event/",
+            state=WebsiteProcessingState.NOT_STARTED,
+            crawler_class="SeventhFloorCrawler",
+        )
+        self.crawler = SeventhFloorCrawler(self.website)
+
+    def test_extract_live_house_info(self):
+        info = self.crawler.extract_live_house_info("")
+        self.assertEqual(info["name"], "7th Floor")
+
+    def test_find_schedule_link_format(self):
+        import datetime
+        from unittest.mock import patch
+
+        with patch("houses.crawlers.seventh_floor.timezone") as mock_tz:
+            mock_tz.localdate.return_value = datetime.date(2026, 6, 1)
+            url = self.crawler.find_schedule_link("")
+        self.assertEqual(url, "http://7th-floor.net/event/?ym=2026-6")
+
+    def test_extract_schedules_filters_by_target_month(self):
+        schedules = self.crawler.extract_performance_schedules(SCHEDULE_HTML)
+        self.assertEqual(len(schedules), 2)
+
+        june7 = schedules[0]
+        self.assertEqual(june7["date"], "2026-06-07")
+        self.assertIn("テストアーティスト1 / テストアーティスト2", june7["performers"])
+        self.assertEqual(june7["performance_name"], "Summer Acoustic Night")
+
+        june20 = schedules[1]
+        self.assertEqual(june20["date"], "2026-06-20")
+        self.assertIn("BandX", june20["performers"])
+
+    def test_may_events_excluded(self):
+        schedules = self.crawler.extract_performance_schedules(SCHEDULE_HTML)
+        dates = [s["date"] for s in schedules]
+        self.assertNotIn("2026-05-10", dates)
+
+    def test_extract_year_month_from_canonical_link(self):
+        soup = self.crawler.create_soup(SCHEDULE_HTML)
+        year, month = self.crawler._extract_target_year_month(soup)
+        self.assertEqual(year, 2026)
+        self.assertEqual(month, 6)
+
+    def test_extract_year_month_falls_back_to_today_when_no_canonical(self):
+        import datetime
+        from unittest.mock import patch
+
+        with patch("houses.crawlers.seventh_floor.timezone") as mock_tz:
+            mock_tz.localdate.return_value = datetime.date(2026, 7, 1)
+            soup = self.crawler.create_soup(NO_CANONICAL_HTML)
+            year, month = self.crawler._extract_target_year_month(soup)
+        self.assertEqual(year, 2026)
+        self.assertEqual(month, 7)


### PR DESCRIPTION
## Summary

- Adds `SeventhFloorCrawler` for `http://7th-floor.net/event/`
- The site loads all events on one page; each `div.eventList` carries a CSS class `YYYY-M` (e.g. `2026-6`) for month filtering
- Date from `span.date` (`MM.DD` format), performers from `ul.artists li`, event title from `h2 span.evTit`
- Target year/month derived from canonical `<link>` `?ym=` parameter; falls back to today's date
- 6 unit tests passing (fixture HTML, no live HTTP)
- Data migration `0016_set_seventh_floor_crawler_class` updates venue 8:
  - `schedule_url` → `http://7th-floor.net/event/` (fixes the 404 stored URL)
  - `crawler_class` → `SeventhFloorCrawler`

## Notes

- The site does not expose open/start times on the listing page (those are detail-page only); times are set to `None`
- The `?ym=YYYY-M` parameter may or may not be honored server-side — extraction filters by CSS class regardless

Closes #127