### PR TITLE
feat(crawler): implement WarpCrawler for Kichijoji WARP

### DIFF
--- a/malcom/houses/crawlers/__init__.py
+++ b/malcom/houses/crawlers/__init__.py
@@ -16,6 +16,7 @@ from .pit_zero import PitZeroCrawler
 from .club_quattro import ClubQuattroCrawler
 from .shinjuku_face import ShinjukuFaceCrawler
 from .seventh_floor import SeventhFloorCrawler
+from .warp import WarpCrawler
 
 __all__ = [
     "LiveHouseWebsiteCrawler",
@@ -37,4 +38,5 @@ __all__ = [
     "ClubQuattroCrawler",
     "ShinjukuFaceCrawler",
     "SeventhFloorCrawler",
+    "WarpCrawler",
 ]

--- a/malcom/houses/crawlers/warp.py
+++ b/malcom/houses/crawlers/warp.py
@@ -1,0 +1,135 @@
+import logging
+import re
+
+from bs4 import BeautifulSoup
+from django.utils import timezone
+
+from .crawler import CrawlerRegistry, LiveHouseWebsiteCrawler
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "http://warp.rinky.info/"
+SCHEDULE_LINK_PATTERN = re.compile(r"/schedules/(\d{4}-\d{2})/(\d+)\.html$")
+DATE_TITLE_PATTERN = re.compile(r"(\d{4})\.(\d{2})\.(\d{2})")
+PERFORMER_SKIP_PATTERN = re.compile(r"^and more\.{0,3}$", re.IGNORECASE)
+TIME_PATTERN = re.compile(r"(\d{1,2}:\d{2})\s*/\s*(\d{1,2}:\d{2})")
+
+
+@CrawlerRegistry.register("WarpCrawler")
+class WarpCrawler(LiveHouseWebsiteCrawler):
+    """Crawler for Kichijoji WARP (http://warp.rinky.info/).
+
+    The homepage lists upcoming events as article[data-aos] elements linking to
+    individual event pages at /schedules/YYYY-MM/ID.html. Each event page contains
+    date (in <title>), performers (in div.w-flyer), and times (in span.strong).
+    """
+
+    def extract_live_house_info(self, html_content: str) -> dict:
+        return {
+            "name": "WARP",
+            "name_kana": "ワープ",
+            "name_romaji": "WARP",
+            "address": "",
+            "phone_number": "",
+            "capacity": 0,
+            "opened_date": None,
+        }
+
+    def find_schedule_link(self, html_content: str) -> str | None:
+        return BASE_URL
+
+    def find_next_month_link(self, html_content: str) -> str | None:
+        """WARP uses one rolling homepage; return the same URL for continuity."""
+        return BASE_URL
+
+    def extract_performance_schedules(self, html_content: str) -> list[dict]:
+        """Extract schedules from the WARP homepage by following event detail links."""
+        soup = self.create_soup(html_content)
+        current = timezone.localdate()
+        target_ym = f"{current.year}-{current.month:02d}"
+
+        event_urls = self._extract_event_urls(soup, target_ym)
+        schedules = []
+        for url in event_urls:
+            schedule = self._fetch_and_parse_event(url)
+            if schedule:
+                schedules.append(schedule)
+
+        logger.info(f"Extracted {len(schedules)} schedules from WARP ({target_ym})")
+        return schedules
+
+    def _extract_event_urls(self, soup: BeautifulSoup, target_ym: str) -> list[str]:
+        urls = []
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            match = SCHEDULE_LINK_PATTERN.search(href)
+            if match and match.group(1) == target_ym:
+                urls.append(href)
+        return list(dict.fromkeys(urls))
+
+    def _fetch_and_parse_event(self, url: str) -> dict | None:
+        try:
+            html = self.fetch_page(url)
+        except OSError as exc:
+            logger.warning(f"Failed to fetch WARP event page {url}: {exc}")
+            return None
+        return self._parse_event_page(html, url)
+
+    def _parse_event_page(self, html_content: str, url: str) -> dict | None:
+        soup = self.create_soup(html_content)
+
+        title_tag = soup.find("title")
+        if not title_tag:
+            return None
+        date_match = DATE_TITLE_PATTERN.search(title_tag.get_text())
+        if not date_match:
+            return None
+        date_str = f"{date_match.group(1)}-{date_match.group(2)}-{date_match.group(3)}"
+
+        detail = soup.find("section", class_="schedules-detail")
+        if not detail:
+            return None
+
+        h4 = detail.find("h4")
+        event_name = h4.get_text(separator=" ").strip() if h4 else None
+
+        performers = self._extract_performers(detail)
+        if not performers:
+            return None
+
+        open_time, start_time = self._extract_times(detail)
+
+        return {
+            "date": date_str,
+            "open_time": open_time,
+            "start_time": start_time,
+            "performers": performers,
+            "performance_name": event_name,
+        }
+
+    def _extract_performers(self, detail: BeautifulSoup) -> list[str]:
+        w_flyer = detail.find("div", class_="w-flyer")
+        if not w_flyer:
+            return []
+        for br in w_flyer.find_all("br"):
+            br.replace_with("\n")
+        lines = w_flyer.get_text().split("\n")
+        performers = []
+        for line in lines:
+            name = line.strip()
+            if not name or PERFORMER_SKIP_PATTERN.match(name):
+                continue
+            performers.append(name)
+        return performers
+
+    def _extract_times(self, detail: BeautifulSoup) -> tuple[str | None, str | None]:
+        notes = detail.find("section", class_="notes-wrapper")
+        if not notes:
+            return None, None
+        strong = notes.find("span", class_="strong")
+        if not strong:
+            return None, None
+        match = TIME_PATTERN.search(strong.get_text())
+        if match:
+            return match.group(1), match.group(2)
+        return None, None

--- a/malcom/houses/migrations/0016_set_warp_crawler_class.py
+++ b/malcom/houses/migrations/0016_set_warp_crawler_class.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def set_warp_crawler_class(apps, schema_editor):
+    LiveHouseWebsite = apps.get_model("houses", "LiveHouseWebsite")
+    LiveHouseWebsite.objects.filter(id=12).update(
+        crawler_class="WarpCrawler",
+        schedule_url="http://warp.rinky.info/",
+    )
+
+
+def reverse_warp_crawler_class(apps, schema_editor):
+    LiveHouseWebsite = apps.get_model("houses", "LiveHouseWebsite")
+    LiveHouseWebsite.objects.filter(id=12, crawler_class="WarpCrawler").update(
+        crawler_class="LiveHouseWebsiteCrawler",
+        schedule_url="http://warp.rinky.info/schedules",
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("houses", "0015_weeklyplaylist_instagram_story_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_warp_crawler_class, reverse_warp_crawler_class),
+    ]

--- a/malcom/houses/tests/test_crawlers_warp.py
+++ b/malcom/houses/tests/test_crawlers_warp.py
@@ -1,0 +1,139 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from houses.crawlers import WarpCrawler
+from houses.definitions import WebsiteProcessingState
+from houses.models import LiveHouseWebsite
+
+HOMEPAGE_HTML = """\
+<!DOCTYPE html>
+<html lang="ja">
+<head><title>ライブハウス吉祥寺ワープ / LIVE HOUSE KICHIJOJI WARP</title></head>
+<body>
+<article data-aos="fade-up">
+  <a href="http://warp.rinky.info/schedules/2026-07/10001.html">
+    <section><img alt="July Event 1" class="lazyload" data-src="x.jpg"/></section>
+  </a>
+</article>
+<article data-aos="fade-up">
+  <a href="http://warp.rinky.info/schedules/2026-07/10002.html">
+    <section><img alt="July Event 2" class="lazyload" data-src="x.jpg"/></section>
+  </a>
+</article>
+<article data-aos="fade-up">
+  <a href="http://warp.rinky.info/schedules/2026-08/10003.html">
+    <section><img alt="August Event" class="lazyload" data-src="x.jpg"/></section>
+  </a>
+</article>
+</body>
+</html>
+"""
+
+EVENT_PAGE_HTML = """\
+<!DOCTYPE html>
+<html lang="ja">
+<head><title>2026.07.05(SUN) | SCHEDULES | ライブハウス吉祥寺ワープ</title></head>
+<body>
+<section class="schedules-detail sun">
+  <h4>夏のライブ「Vol.1」</h4>
+  <section>
+    <div class="w-flyer">BandAlpha<br/>
+      BandBeta<br/>
+      BandGamma<br/>
+      and more...<div class="detail-texts"></div>
+      <section class="notes-wrapper">
+        <p>OPEN / START<br/><span class="strong">18:00 / 18:30</span></p>
+      </section>
+    </div>
+  </section>
+</section>
+</body>
+</html>
+"""
+
+EVENT_PAGE_HTML_2 = """\
+<!DOCTYPE html>
+<html lang="ja">
+<head><title>2026.07.12(SAT) | SCHEDULES | ライブハウス吉祥寺ワープ</title></head>
+<body>
+<section class="schedules-detail sat">
+  <h4>夏のライブ「Vol.2」</h4>
+  <section>
+    <div class="w-flyer">BandDelta<br/>
+      BandEpsilon<br/>
+      <section class="notes-wrapper">
+        <p>OPEN / START<br/><span class="strong">TBA / TBA</span></p>
+      </section>
+    </div>
+  </section>
+</section>
+</body>
+</html>
+"""
+
+
+class TestWarpCrawler(TestCase):
+    def setUp(self):
+        self.website = LiveHouseWebsite.objects.create(
+            url="http://warp.rinky.info/",
+            state=WebsiteProcessingState.NOT_STARTED,
+            crawler_class="WarpCrawler",
+        )
+        self.crawler = WarpCrawler(self.website)
+
+    def test_extract_live_house_info(self):
+        info = self.crawler.extract_live_house_info("")
+        self.assertEqual(info["name"], "WARP")
+
+    def test_find_schedule_link(self):
+        self.assertEqual(self.crawler.find_schedule_link(""), "http://warp.rinky.info/")
+
+    def test_extract_event_urls_filters_by_month(self):
+        import datetime
+
+        with patch("houses.crawlers.warp.timezone") as mock_tz:
+            mock_tz.localdate.return_value = datetime.date(2026, 7, 1)
+            soup = self.crawler.create_soup(HOMEPAGE_HTML)
+            urls = self.crawler._extract_event_urls(soup, "2026-07")
+
+        self.assertEqual(len(urls), 2)
+        self.assertIn("http://warp.rinky.info/schedules/2026-07/10001.html", urls)
+        self.assertIn("http://warp.rinky.info/schedules/2026-07/10002.html", urls)
+        self.assertNotIn("http://warp.rinky.info/schedules/2026-08/10003.html", urls)
+
+    def test_parse_event_page_extracts_date_and_performers(self):
+        schedule = self.crawler._parse_event_page(EVENT_PAGE_HTML, "http://x/10001.html")
+        self.assertIsNotNone(schedule)
+        self.assertEqual(schedule["date"], "2026-07-05")
+        self.assertEqual(schedule["open_time"], "18:00")
+        self.assertEqual(schedule["start_time"], "18:30")
+        self.assertIn("BandAlpha", schedule["performers"])
+        self.assertIn("BandBeta", schedule["performers"])
+        self.assertIn("BandGamma", schedule["performers"])
+        self.assertNotIn("and more...", schedule["performers"])
+        self.assertEqual(schedule["performance_name"], "夏のライブ「Vol.1」")
+
+    def test_parse_event_page_tba_times_are_none(self):
+        schedule = self.crawler._parse_event_page(EVENT_PAGE_HTML_2, "http://x/10002.html")
+        self.assertIsNotNone(schedule)
+        self.assertIsNone(schedule["open_time"])
+        self.assertIsNone(schedule["start_time"])
+
+    def test_extract_performance_schedules_fetches_event_pages(self):
+        import datetime
+
+        pages = {
+            "http://warp.rinky.info/schedules/2026-07/10001.html": EVENT_PAGE_HTML,
+            "http://warp.rinky.info/schedules/2026-07/10002.html": EVENT_PAGE_HTML_2,
+        }
+
+        with patch("houses.crawlers.warp.timezone") as mock_tz:
+            mock_tz.localdate.return_value = datetime.date(2026, 7, 1)
+            with patch.object(self.crawler, "fetch_page", side_effect=lambda url: pages[url]):
+                schedules = self.crawler.extract_performance_schedules(HOMEPAGE_HTML)
+
+        self.assertEqual(len(schedules), 2)
+        dates = [s["date"] for s in schedules]
+        self.assertIn("2026-07-05", dates)
+        self.assertIn("2026-07-12", dates)


### PR DESCRIPTION
## Summary

- Adds `WarpCrawler` for `http://warp.rinky.info/`
- **No Playwright needed** — the WARP site serves all event data in static HTML
- Strategy: crawl the rolling homepage to collect upcoming event links matching `/schedules/YYYY-MM/`, then follow each link to its detail page
- Detail page structure: date from `<title>` (`YYYY.MM.DD`), performers from `div.w-flyer` (`<br/>`-separated), times from `section.notes-wrapper span.strong`
- Skips "and more..." lines from performer list
- TBA times → `None`
- 6 unit tests passing (fixture HTML + mocked `fetch_page`, no live HTTP)
- Data migration `0016_set_warp_crawler_class` updates venue 12:
  - `schedule_url` → `http://warp.rinky.info/`
  - `crawler_class` → `WarpCrawler`

## Notes

- The homepage shows only upcoming/future events; past-month schedules are not retrievable via this approach
- Monthly archive pages (`/schedules/YYYY-MM/`) return 404 for months with no direct archive
- Coverage matches issue AC: "≥5 schedules for June or July 2026" (July has 7 events visible from homepage)

Partially closes #124
Closes #129